### PR TITLE
Add notices table with RLS policies and publish form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
+import Publish from "./pages/Publish";
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/publish" element={<Publish />} />
       </Routes>
     </Router>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -305,7 +305,7 @@ export default function Home() {
                 Sign in
               </a>
               <a
-                href="#publish"
+                href="/publish"
                 onClick={() => track("publish_started", { audience: "public" })}
                 className="h-11 px-5 rounded-xl bg-blue-600 text-white hover:bg-blue-700 text-sm font-semibold inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600"
               >
@@ -316,7 +316,7 @@ export default function Home() {
             {/* Mobile: Publish stays visible + hamburger for sheet */}
             <div className="md:hidden flex items-center gap-2">
               <a
-                href="#publish"
+                href="/publish"
                 onClick={() => track("publish_started", { audience: "public" })}
                 className="h-10 px-3 rounded-xl bg-blue-600 text-white hover:bg-blue-700 text-sm font-semibold inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600"
                 aria-label="Publish a notice"
@@ -374,7 +374,7 @@ export default function Home() {
                   Sign in
                 </a>
                 <a
-                  href="#publish"
+                  href="/publish"
                   onClick={() => { setMobileOpen(false); track("publish_started", { audience: "public" }); }}
                   className="h-11 px-5 rounded-xl bg-blue-600 text-white hover:bg-blue-700 text-sm font-semibold inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-600"
                 >
@@ -654,13 +654,14 @@ export default function Home() {
           </ol>
 
           <div className="mt-10 flex justify-center">
-            <button
+            <a
+              href="/publish"
               className="inline-flex h-11 items-center gap-2 rounded-xl bg-blue-600 px-5 text-sm text-white font-semibold hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-600"
               onClick={() => track("publish_started", { audience: "public" })}
             >
               Publish a notice
               <ArrowRight className="h-4 w-4" aria-hidden="true" />
-            </button>
+            </a>
           </div>
         </div>
       </section>

--- a/src/pages/Publish.tsx
+++ b/src/pages/Publish.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+
+interface NoticeForm {
+  type: string;
+  title: string;
+  address: string;
+  description: string;
+  opening_hours: string;
+}
+
+export default function Publish() {
+  const [form, setForm] = useState<NoticeForm>({
+    type: "",
+    title: "",
+    address: "",
+    description: "",
+    opening_hours: "",
+  });
+  const [status, setStatus] = useState<string | null>(null);
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus(null);
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/notices`,
+        {
+          method: "POST",
+          headers: {
+            apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+            Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+            "Content-Type": "application/json",
+            Prefer: "return=representation",
+          },
+          body: JSON.stringify(form),
+        }
+      );
+      if (!res.ok) throw new Error(await res.text());
+      setStatus("Notice published!");
+      setForm({ type: "", title: "", address: "", description: "", opening_hours: "" });
+    } catch {
+      setStatus("Failed to publish notice");
+    }
+  }
+
+  return (
+    <main className="max-w-xl mx-auto py-8 px-4">
+      <h1 className="text-2xl font-semibold mb-4">Publish a Notice</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          name="type"
+          value={form.type}
+          onChange={handleChange}
+          required
+          className="w-full rounded border border-slate-300 p-2"
+          placeholder="Type"
+        />
+        <input
+          name="title"
+          value={form.title}
+          onChange={handleChange}
+          required
+          className="w-full rounded border border-slate-300 p-2"
+          placeholder="Title"
+        />
+        <input
+          name="address"
+          value={form.address}
+          onChange={handleChange}
+          className="w-full rounded border border-slate-300 p-2"
+          placeholder="Address"
+        />
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          className="w-full rounded border border-slate-300 p-2"
+          placeholder="Description"
+        />
+        <input
+          name="opening_hours"
+          value={form.opening_hours}
+          onChange={handleChange}
+          className="w-full rounded border border-slate-300 p-2"
+          placeholder="Opening hours"
+        />
+        <button
+          type="submit"
+          className="h-10 px-4 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Submit
+        </button>
+      </form>
+      {status && <p className="mt-4 text-sm text-slate-600">{status}</p>}
+    </main>
+  );
+}
+

--- a/supabase/migrations/20250811130645_create_notices_table.sql
+++ b/supabase/migrations/20250811130645_create_notices_table.sql
@@ -1,0 +1,33 @@
+-- Create notices table with RLS policies
+create table if not exists public.notices (
+  id bigint generated always as identity primary key,
+  type text not null,
+  title text not null,
+  address text,
+  description text,
+  opening_hours text,
+  created_at timestamptz not null default now()
+);
+
+-- Enable Row Level Security
+alter table public.notices enable row level security;
+
+-- Grant access privileges
+grant select on public.notices to anon, authenticated;
+grant insert, update on public.notices to authenticated;
+
+-- Policies
+create policy "Public read access" on public.notices
+  for select
+  using (true);
+
+create policy "Authenticated insert" on public.notices
+  for insert
+  to authenticated
+  with check (true);
+
+create policy "Authenticated update" on public.notices
+  for update
+  to authenticated
+  using (true)
+  with check (true);


### PR DESCRIPTION
## Summary
- create `notices` table with columns for type, title, address, description and timestamps
- enable row level security and policies for public reads and authenticated inserts/updates
- add a form for publishing notices and link home page buttons to it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / unused variables in src/pages/Home.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6899e839836c833095b8338b80aabff9