### PR TITLE
handle unsupported geolocation API

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -208,7 +208,12 @@ export default function Home() {
   function handleGeo() {
     setGeoError("");
     setGeoLoading(true);
-    navigator.geolocation?.getCurrentPosition(
+    if (!navigator.geolocation) {
+      setGeoLoading(false);
+      setGeoError("Your browser doesn't support location. Enter postcode or ward.");
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
       (pos) => {
         setGeoLoading(false);
         track("search_submit", { source: "hero", query: "geo", geo_used: true, audience: "public" });


### PR DESCRIPTION
## Summary
- guard geolocation usage when browser lacks `navigator.geolocation`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f86e07588330be836c91389b9823