### PR TITLE
Simplify routing and clean TS config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .next
 dist
 build
+*.tsbuildinfo
 
 # OS files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc --noEmit && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,15 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
 import Publish from "./pages/Publish";
 
 export default function App() {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/publish" element={<Publish />} />
-      </Routes>
-    </Router>
-  );
+  const path = window.location.pathname;
+  switch (path) {
+    case "/dashboard":
+      return <Dashboard />;
+    case "/publish":
+      return <Publish />;
+    default:
+      return <Home />;
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,4 @@
 {
-  "files": [],
-  "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ],
   "compilerOptions": {
     "target": "ES2017",
     "lib": [


### PR DESCRIPTION
## Summary
- replace react-router routing with simple pathname switch
- drop unused TypeScript project references and use `tsc --noEmit` before build
- ignore generated `.tsbuildinfo` files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a07489e1c8330a47504b329624971