### PR TITLE
fix: expose dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+  },
 })


### PR DESCRIPTION
## Summary
- ensure Vite dev server listens on all interfaces

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`
- `npm run dev` (shows `Network: http://172.30.0.2:5173/`)


------
https://chatgpt.com/codex/tasks/task_e_689a0fcb1d348330918fb545da965546