### PR TITLE
fix: update premises licence form options

### DIFF
--- a/src/components/publish/NoticeTypeSelect.tsx
+++ b/src/components/publish/NoticeTypeSelect.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const options: { value: NoticeType; label: string }[] = [
-  { value: 'premises', label: 'Premises licence' },
+  { value: 'premises', label: 'Premises Licence' },
   { value: 'traffic', label: 'Traffic notice' },
   { value: 'gambling', label: 'Gambling licence' },
 ];

--- a/src/components/publish/PremisesForm.tsx
+++ b/src/components/publish/PremisesForm.tsx
@@ -26,8 +26,9 @@ interface Props {
 }
 
 const activityOptions = [
-  'Sale of alcohol',
+  'Sale of alcohol on/off the premises',
   'Live music',
+  'Recorded music',
   'Late night refreshment',
 ];
 
@@ -105,7 +106,7 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) 
 
   return (
     <form onSubmit={submit} className="mt-6 space-y-5" aria-describedby="premises-desc">
-      <p id="premises-desc" className="sr-only">Premises licence application form</p>
+      <p id="premises-desc" className="sr-only">Premises Licence application form</p>
 
       <div className="space-y-2">
         <label htmlFor="addressSearch" className="block text-sm font-medium text-slate-700">

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -18,7 +18,7 @@ export default function PublishPage() {
     if (type && announceRef.current) {
       const label =
         type === 'premises'
-          ? 'Premises licence form'
+          ? 'Premises Licence form'
           : type === 'traffic'
           ? 'Traffic notice form'
           : 'Gambling licence form';


### PR DESCRIPTION
## Summary
- Capitalize Premises Licence label
- Add recorded music and on/off premises alcohol sale options

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_689b19d1f3f88330923a4c034a27f815