### PR TITLE
Remove postcode field and add universal hours option

### DIFF
--- a/src/__tests__/noticeTemplate.test.ts
+++ b/src/__tests__/noticeTemplate.test.ts
@@ -1,0 +1,39 @@
+import { generateNotice, Hours } from '../lib/noticeTemplate';
+
+describe('notice template', () => {
+  it('renders with substitutions', () => {
+    const hours: Hours = {};
+    ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].forEach((d) => {
+      hours[d] = { start: '09:00', end: '23:00' };
+    });
+    const form = {
+      applicationType: 'New Premises Licence',
+      applicantName: 'Jane Smith',
+      premisesName: 'The Bar',
+      premisesAddress: '1 High St, Town AB1 2CD',
+      councilName: 'Sample Council',
+      activities: ['Sale of alcohol (on premises)'],
+      activityHours: { 'Sale of alcohol (on premises)': hours },
+      openingHours: hours,
+      representationDeadline: '2025-01-01',
+      licensingManager: 'Manager Name',
+      councilDepartment: 'Licensing Dept',
+      councilOfficeAddress: '1 Council St',
+      viewingStartTime: '09:00',
+      viewingEndTime: '17:00',
+      viewingDays: 'Mon-Fri',
+      councilWebsite: 'http://council.example.com',
+      councilLicensingEmail: 'license@example.com',
+      applicationDate: '2025-01-02',
+    };
+    const expected = `Notice of Application for a New Premises Licence
+
+I, Jane Smith Address of Premises: The Bar, 1 High St, Town, AB1 2CD have made the above application on 2025-01-02 to Sample Council for:
+Sale of alcohol (on premises)
+Mon–Sun: 09:00–23:00 and opening hours Monday to Sunday 09:00 to 23:00.
+The full application can be viewed at Sample Council. Contact Manager Name, Licensing Dept, 1 Council St, between the hours of 09:00 and 17:00 on Mon-Fri, visit http://council.example.com, or email: license@example.com.
+A Responsible Authority or Other Persons may make written representations about this application to the Licensing Office on or before 2025-01-01.
+It is an offence, knowingly or recklessly, to make a false statement in connection with an application, and on summary conviction is liable to an unlimited fine.`;
+    expect(generateNotice(form)).toBe(expected);
+  });
+});

--- a/src/__tests__/premisesForm.test.tsx
+++ b/src/__tests__/premisesForm.test.tsx
@@ -1,0 +1,28 @@
+import { render, fireEvent, within } from '@testing-library/react';
+import React from 'react';
+import PremisesForm, { WeeklyHoursInput } from '../components/publish/PremisesForm';
+
+describe('PremisesForm', () => {
+  it('has no postcode field', () => {
+    const { queryByLabelText } = render(
+      <PremisesForm onSubmit={() => {}} saving={false} autoFocusRef={{ current: null }} />
+    );
+    expect(queryByLabelText(/Postcode/i)).toBeNull();
+  });
+
+  it('Every Day autofill populates all days', () => {
+    const onChange = vi.fn();
+    const { getByText } = render(
+      <WeeklyHoursInput value={{}} onChange={onChange} />
+    );
+    const row = getByText('Every Day').closest('tr')!;
+    const inputs = within(row).getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: '09:00' } });
+    fireEvent.change(inputs[1], { target: { value: '17:00' } });
+    const expected: Record<string, { start: string; end: string }> = {};
+    ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].forEach((d) => {
+      expected[d] = { start: '09:00', end: '17:00' };
+    });
+    expect(onChange).toHaveBeenLastCalledWith(expected);
+  });
+});

--- a/src/components/publish/PremisesForm.tsx
+++ b/src/components/publish/PremisesForm.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { generateNotice } from '../../lib/noticeTemplate';
 
 export type ApplicationType =
   | 'New Premises Licence'
@@ -36,7 +37,6 @@ interface FormData {
   applicationType: ApplicationType;
   premisesName: string;
   premisesAddress: string;
-  postcode: string;
   applicantName: string;
   councilName: string;
   inspectionMethod: string;
@@ -67,7 +67,7 @@ interface Props {
   autoFocusRef: React.RefObject<HTMLInputElement>;
 }
 
-function WeeklyHoursInput({
+export function WeeklyHoursInput({
   value,
   onChange,
   label,
@@ -80,11 +80,36 @@ function WeeklyHoursInput({
     onChange({ ...value, [day]: { ...value[day], [field]: val } });
   }
 
+  function setEveryDay(field: 'start' | 'end', val: string) {
+    const updated: Hours = { ...value };
+    days.forEach((d) => {
+      updated[d] = { ...updated[d], [field]: val };
+    });
+    onChange(updated);
+  }
+
   return (
     <div className="space-y-1">
       {label && <p className="font-medium">{label}</p>}
       <table className="w-full text-sm">
         <tbody>
+          <tr className="odd:bg-slate-50">
+            <td className="pr-2 py-1 w-16">Every Day</td>
+            <td className="pr-2">
+              <input
+                type="time"
+                onChange={(e) => setEveryDay('start', e.target.value)}
+                className="w-full border rounded p-1"
+              />
+            </td>
+            <td>
+              <input
+                type="time"
+                onChange={(e) => setEveryDay('end', e.target.value)}
+                className="w-full border rounded p-1"
+              />
+            </td>
+          </tr>
           {days.map((d) => (
             <tr key={d} className="odd:bg-slate-50">
               <td className="pr-2 py-1 w-16">{d}</td>
@@ -112,138 +137,12 @@ function WeeklyHoursInput({
   );
 }
 
-function formatHours(hours: Hours): string {
-  const result: string[] = [];
-  let i = 0;
-  while (i < days.length) {
-    const day = days[i];
-    const h = hours[day];
-    if (!h?.start || !h?.end) {
-      i++;
-      continue;
-    }
-    const start = h.start;
-    const end = h.end;
-    let j = i + 1;
-    while (
-      j < days.length &&
-      hours[days[j]]?.start === start &&
-      hours[days[j]]?.end === end
-    ) {
-      j++;
-    }
-    const label = i + 1 === j ? days[i] : `${days[i]}–${days[j - 1]}`;
-    result.push(`${label}: ${start}–${end}`);
-    i = j;
-  }
-  return result.join('\n');
-}
-
-const templates: Record<ApplicationType, string> = {
-  'New Premises Licence': `APPLICATION FOR A {{APPLICATION_TYPE}}
-
-{{APPLICANT_NAME}} has applied to {{COUNCIL_NAME}} for a {{APPLICATION_TYPE}} at:
-{{PREMISES_NAME}}, {{PREMISES_ADDRESS}}, {{POSTCODE}}.
-
-Licensable activities and hours:
-{{ACTIVITY_HOURS_BLOCK}}
-
-Opening hours:
-{{OPENING_HOURS_BLOCK}}
-
-Inspection of the application:
-{{INSPECTION_METHOD}}
-
-Representations:
-Anyone wishing to make representations must do so by {{REPRESENTATION_DEADLINE}}.
-{{REPRESENTATION_METHOD}}
-
-(Representations must relate to the licensing objectives. It is an offence to knowingly or recklessly make a false statement in connection with an application.)`,
-  'Variation of Premises Licence': `APPLICATION FOR A {{APPLICATION_TYPE}}
-
-{{APPLICANT_NAME}} has applied to {{COUNCIL_NAME}} for a {{APPLICATION_TYPE}} at:
-{{PREMISES_NAME}}, {{PREMISES_ADDRESS}}, {{POSTCODE}}.
-
-Summary of proposed variation:
-{{VARIATION_SUMMARY}}
-
-Licensable activities and hours (as varied):
-{{ACTIVITY_HOURS_BLOCK}}
-
-Opening hours (as varied):
-{{OPENING_HOURS_BLOCK}}
-
-Inspection of the application:
-{{INSPECTION_METHOD}}
-
-Representations:
-Anyone wishing to make representations must do so by {{REPRESENTATION_DEADLINE}}.
-{{REPRESENTATION_METHOD}}
-
-(Representations must relate to the licensing objectives. It is an offence to knowingly or recklessly make a false statement in connection with an application.)`,
-  'Minor Variation': `APPLICATION FOR A {{APPLICATION_TYPE}}
-
-{{APPLICANT_NAME}} has applied to {{COUNCIL_NAME}} for a {{APPLICATION_TYPE}} at:
-{{PREMISES_NAME}}, {{PREMISES_ADDRESS}}, {{POSTCODE}}.
-
-Brief description of the proposed minor changes:
-{{VARIATION_SUMMARY}}
-
-Licensable activities/hours affected (if applicable):
-{{ACTIVITY_HOURS_BLOCK}}
-
-Inspection of the application:
-{{INSPECTION_METHOD}}
-
-Comments/Representations:
-Interested parties may submit comments by {{REPRESENTATION_DEADLINE}}.
-{{REPRESENTATION_METHOD}}`,
-  'Club Premises Certificate (new)': `APPLICATION FOR A {{APPLICATION_TYPE}}
-
-{{APPLICANT_NAME}} has applied to {{COUNCIL_NAME}} for a {{APPLICATION_TYPE}} for:
-{{PREMISES_NAME}}, {{PREMISES_ADDRESS}}, {{POSTCODE}}.
-
-Qualifying club activities and hours:
-{{ACTIVITY_HOURS_BLOCK}}
-
-Opening hours (if applicable):
-{{OPENING_HOURS_BLOCK}}
-
-Inspection of the application:
-{{INSPECTION_METHOD}}
-
-Representations:
-Anyone wishing to make representations must do so by {{REPRESENTATION_DEADLINE}}.
-{{REPRESENTATION_METHOD}}
-
-(Representations must relate to the licensing objectives. It is an offence to knowingly or recklessly make a false statement in connection with an application.)`,
-  'Variation of Club Premises Certificate': `APPLICATION FOR A {{APPLICATION_TYPE}}
-
-{{APPLICANT_NAME}} has applied to {{COUNCIL_NAME}} for a {{APPLICATION_TYPE}} for:
-{{PREMISES_NAME}}, {{PREMISES_ADDRESS}}, {{POSTCODE}}.
-
-Qualifying club activities and hours:
-{{ACTIVITY_HOURS_BLOCK}}
-
-Opening hours (if applicable):
-{{OPENING_HOURS_BLOCK}}
-
-Inspection of the application:
-{{INSPECTION_METHOD}}
-
-Representations:
-Anyone wishing to make representations must do so by {{REPRESENTATION_DEADLINE}}.
-{{REPRESENTATION_METHOD}}
-
-(Representations must relate to the licensing objectives. It is an offence to knowingly or recklessly make a false statement in connection with an application.)`,
-};
 
 export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) {
   const [form, setForm] = useState<FormData>({
     applicationType: 'New Premises Licence',
     premisesName: '',
     premisesAddress: '',
-    postcode: '',
     applicantName: '',
     councilName: '',
     inspectionMethod: '',
@@ -289,27 +188,7 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) 
     }));
   }
 
-  const noticeText = useMemo(() => {
-    const activityBlock = form.activities
-      .map((a) => `${a}\n${formatHours(form.activityHours[a] || {})}`)
-      .join('\n\n');
-    const opening = formatHours(form.openingHours);
-    const template = templates[form.applicationType];
-    return template
-      .replace(/\{\{APPLICATION_TYPE\}\}/g, form.applicationType)
-      .replace(/\{\{COUNCIL_NAME\}\}/g, form.councilName)
-      .replace(/\{\{PREMISES_NAME\}\}/g, form.premisesName)
-      .replace(/\{\{PREMISES_ADDRESS\}\}/g, form.premisesAddress)
-      .replace(/\{\{POSTCODE\}\}/g, form.postcode)
-      .replace(/\{\{APPLICANT_NAME\}\}/g, form.applicantName)
-      .replace(/\{\{ACTIVITY_HOURS_BLOCK\}\}/g, activityBlock)
-      .replace(/\{\{OPENING_HOURS_BLOCK\}\}/g, opening)
-      .replace(/\{\{VARIATION_SUMMARY\}\}/g, form.variationSummary)
-      .replace(/\{\{INSPECTION_METHOD\}\}/g, form.inspectionMethod)
-      .replace(/\{\{REPRESENTATION_METHOD\}\}/g, form.representationMethod)
-      .replace(/\{\{REPRESENTATION_DEADLINE\}\}/g, form.representationDeadline)
-      .replace(/\{\{REFERENCE\}\}/g, form.reference);
-  }, [form]);
+  const noticeText = useMemo(() => generateNotice(form), [form]);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -371,19 +250,6 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) 
             id="premisesAddress"
             name="premisesAddress"
             value={form.premisesAddress}
-            onChange={handleChange}
-            className="w-full rounded border border-slate-300 p-2"
-            required
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-slate-700" htmlFor="postcode">
-            Postcode
-          </label>
-          <input
-            id="postcode"
-            name="postcode"
-            value={form.postcode}
             onChange={handleChange}
             className="w-full rounded border border-slate-300 p-2"
             required

--- a/src/lib/noticeTemplate.ts
+++ b/src/lib/noticeTemplate.ts
@@ -1,0 +1,95 @@
+export interface Hours {
+  [day: string]: { start: string; end: string };
+}
+
+const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+function formatHours(hours: Hours): string {
+  const result: string[] = [];
+  let i = 0;
+  while (i < days.length) {
+    const day = days[i];
+    const h = hours[day];
+    if (!h?.start || !h?.end) {
+      i++;
+      continue;
+    }
+    const start = h.start;
+    const end = h.end;
+    let j = i + 1;
+    while (
+      j < days.length &&
+      hours[days[j]]?.start === start &&
+      hours[days[j]]?.end === end
+    ) {
+      j++;
+    }
+    const label = i + 1 === j ? days[i] : `${days[i]}–${days[j - 1]}`;
+    result.push(`${label}: ${start}–${end}`);
+    i = j;
+  }
+  return result.join('\n');
+}
+
+function extractAddressAndPostcode(address: string): { address: string; postcode: string } {
+  const match = address.match(/(.*)\b([A-Z]{1,2}\d{1,2}[A-Z]?\s*\d[A-Z]{2})$/i);
+  if (match) {
+    return {
+      address: match[1].trim().replace(/,?$/, ''),
+      postcode: match[2].toUpperCase(),
+    };
+  }
+  return { address, postcode: '' };
+}
+
+function summarizeOpeningHours(hours: Hours): { days: string; start: string; end: string } {
+  const first = hours['Mon'];
+  if (!first?.start || !first?.end) return { days: '', start: '', end: '' };
+  const allSame = days.every((d) => hours[d]?.start === first.start && hours[d]?.end === first.end);
+  if (allSame) {
+    return { days: 'Monday to Sunday', start: first.start, end: first.end };
+  }
+  return { days: '', start: '', end: '' };
+}
+
+const template = `Notice of Application for a [APPLICATION_TYPE]
+
+I, [APPLICANT FULL NAME] Address of Premises: [PREMISES NAME], [PREMISES ADDRESS], [POSTCODE] have made the above application on [APPLICATION DATE] to [COUNCIL NAME] for:
+[LICENSABLE ACTIVITIES AND DESCRIPTION] and opening hours [DAYS] [START TIME] to [END TIME].
+The full application can be viewed at [COUNCIL NAME]. Contact [LICENSING MANAGER / OFFICER], [COUNCIL DEPARTMENT / OFFICE NAME], [COUNCIL OFFICE ADDRESS], between the hours of [VIEWING START TIME] and [VIEWING END TIME] on [VIEWING DAYS], visit [COUNCIL WEBSITE], or email: [COUNCIL LICENSING EMAIL].
+A Responsible Authority or Other Persons may make written representations about this application to the Licensing Office on or before [REPRESENTATION DEADLINE DATE].
+It is an offence, knowingly or recklessly, to make a false statement in connection with an application, and on summary conviction is liable to an unlimited fine.`;
+
+export function generateNotice(form: any): string {
+  const { address, postcode } = extractAddressAndPostcode(form.premisesAddress || '');
+  const activityBlock = (form.activities || [])
+    .map((a: string) => `${a}\n${formatHours(form.activityHours?.[a] || {})}`)
+    .join('\n\n');
+  const opening = summarizeOpeningHours(form.openingHours || {});
+  const replacements: Record<string, string> = {
+    'APPLICATION_TYPE': form.applicationType || '',
+    'APPLICANT FULL NAME': form.applicantName || '',
+    'PREMISES NAME': form.premisesName || '',
+    'PREMISES ADDRESS': address,
+    'POSTCODE': postcode,
+    'APPLICATION DATE': form.applicationDate || new Date().toLocaleDateString('en-GB'),
+    'COUNCIL NAME': form.councilName || '',
+    'LICENSABLE ACTIVITIES AND DESCRIPTION': activityBlock,
+    'DAYS': opening.days,
+    'START TIME': opening.start,
+    'END TIME': opening.end,
+    'LICENSING MANAGER / OFFICER': form.licensingManager || '',
+    'COUNCIL DEPARTMENT / OFFICE NAME': form.councilDepartment || '',
+    'COUNCIL OFFICE ADDRESS': form.councilOfficeAddress || '',
+    'VIEWING START TIME': form.viewingStartTime || '',
+    'VIEWING END TIME': form.viewingEndTime || '',
+    'VIEWING DAYS': form.viewingDays || '',
+    'COUNCIL WEBSITE': form.councilWebsite || '',
+    'COUNCIL LICENSING EMAIL': form.councilLicensingEmail || form.councilEmail || '',
+    'REPRESENTATION DEADLINE DATE': form.representationDeadline || '',
+  };
+  let text = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    text = text.replaceAll(`[${key}]`, value);
+  }
+  return text;
+}

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -38,7 +38,6 @@ export default function PublishPage() {
         address_line1: data.address_line1 ?? null,
         address_line2: data.address_line2 ?? null,
         city: data.city ?? null,
-        postcode: data.postcode ?? null,
         status: 'draft',
       });
       if (error) throw error;


### PR DESCRIPTION
## Summary
- drop separate postcode input and related API field
- add "Every Day" autofill to opening hours
- replace notice generator with new template and substitution logic
- add tests covering new template, daily hours autofill, and absence of postcode field

## Testing
- `npm test` *(fails: MISSING DEPENDENCY Cannot find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_689b25f1f6948330a6e376d7beefa171