### PR TITLE
Implement licensing notice template and form updates

### DIFF
--- a/src/__tests__/noticeTemplate.test.ts
+++ b/src/__tests__/noticeTemplate.test.ts
@@ -1,39 +1,85 @@
+import { describe, expect, it } from 'vitest';
 import { generateNotice, Hours } from '../lib/noticeTemplate';
 
-describe('notice template', () => {
-  it('renders with substitutions', () => {
-    const hours: Hours = {};
-    ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].forEach((d) => {
-      hours[d] = { start: '09:00', end: '23:00' };
-    });
-    const form = {
-      applicationType: 'New Premises Licence',
-      applicantName: 'Jane Smith',
-      premisesName: 'The Bar',
-      premisesAddress: '1 High St, Town AB1 2CD',
-      councilName: 'Sample Council',
-      activities: ['Sale of alcohol (on premises)'],
-      activityHours: { 'Sale of alcohol (on premises)': hours },
-      openingHours: hours,
-      representationDeadline: '2025-01-01',
-      licensingManager: 'Manager Name',
-      councilDepartment: 'Licensing Dept',
-      councilOfficeAddress: '1 Council St',
-      viewingStartTime: '09:00',
-      viewingEndTime: '17:00',
-      viewingDays: 'Mon-Fri',
-      councilWebsite: 'http://council.example.com',
-      councilLicensingEmail: 'license@example.com',
-      applicationDate: '2025-01-02',
-    };
-    const expected = `Notice of Application for a New Premises Licence
+const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
-I, Jane Smith Address of Premises: The Bar, 1 High St, Town, AB1 2CD have made the above application on 2025-01-02 to Sample Council for:
-Sale of alcohol (on premises)
-Mon–Sun: 09:00–23:00 and opening hours Monday to Sunday 09:00 to 23:00.
-The full application can be viewed at Sample Council. Contact Manager Name, Licensing Dept, 1 Council St, between the hours of 09:00 and 17:00 on Mon-Fri, visit http://council.example.com, or email: license@example.com.
-A Responsible Authority or Other Persons may make written representations about this application to the Licensing Office on or before 2025-01-01.
-It is an offence, knowingly or recklessly, to make a false statement in connection with an application, and on summary conviction is liable to an unlimited fine.`;
-    expect(generateNotice(form)).toBe(expected);
+function makeHours(start: string, end: string): Hours {
+  const h: Hours = {};
+  days.forEach((d) => {
+    h[d] = { start, end };
+  });
+  return h;
+}
+
+describe('notice template', () => {
+  const baseForm = {
+    applicationType: 'Grant of a Premises Licence',
+    applicantName: 'Jane Smith',
+    councilName: 'Sample Council',
+    premisesName: 'The Bar',
+    premisesAddress: '1 High St, Town, AB1 2CD',
+    councilPostalAddress: 'Sample Council, Plough Lane, HR4 0LE',
+    councilOfficeHours: '09:30 – 13:30',
+    councilApplicationsUrl: 'http://council.example.com',
+    representationDeadline: '1 February 2025',
+    activities: ['On and Off Sale of Alcohol'],
+    activityHours: { 'On and Off Sale of Alcohol': makeHours('11:00', '23:00') },
+  };
+
+  it('renders daily hours with DAILY label', () => {
+    const notice = generateNotice(baseForm);
+    expect(notice).toContain(
+      'On and Off Sale of Alcohol – 11:00 to 23:00hrs - DAILY'
+    );
+  });
+
+  it('groups day ranges', () => {
+    const hours: Hours = {
+      Mon: { start: '11:00', end: '23:00' },
+      Tue: { start: '11:00', end: '23:00' },
+      Wed: { start: '11:00', end: '23:00' },
+      Thu: { start: '11:00', end: '23:00' },
+      Fri: { start: '11:00', end: '01:00' },
+      Sat: { start: '11:00', end: '01:00' },
+      Sun: { start: '12:00', end: '22:30' },
+    };
+    const form = {
+      ...baseForm,
+      activityHours: { 'On and Off Sale of Alcohol': hours },
+    };
+    const notice = generateNotice(form);
+    expect(notice).toContain(
+      'On and Off Sale of Alcohol – 11:00 to 23:00hrs - Mon–Thu'
+    );
+    expect(notice).toContain(
+      'On and Off Sale of Alcohol – 11:00 to 01:00hrs - Fri–Sat'
+    );
+    expect(notice).toContain(
+      'On and Off Sale of Alcohol – 12:00 to 22:30hrs - Sun'
+    );
+  });
+
+  it('renders cross-midnight end time verbatim', () => {
+    const notice = generateNotice({
+      ...baseForm,
+      activityHours: {
+        'On and Off Sale of Alcohol': makeHours('10:00', '01:00'),
+      },
+    });
+    expect(notice).toContain('10:00 to 01:00');
+  });
+
+  it('omits premises name when empty', () => {
+    const notice = generateNotice({ ...baseForm, premisesName: '' });
+    expect(notice).toContain('at 1 High St, Town, AB1 2CD in which');
+    expect(notice).not.toContain('at ,');
+  });
+
+  it('uses manual representation deadline verbatim', () => {
+    const notice = generateNotice({
+      ...baseForm,
+      representationDeadline: '31 Dec 2025',
+    });
+    expect(notice).toContain('no later than: 31 Dec 2025');
   });
 });

--- a/src/components/publish/PremisesForm.tsx
+++ b/src/components/publish/PremisesForm.tsx
@@ -2,29 +2,29 @@ import React, { useMemo, useState } from 'react';
 import { generateNotice } from '../../lib/noticeTemplate';
 
 export type ApplicationType =
-  | 'New Premises Licence'
-  | 'Variation of Premises Licence'
-  | 'Minor Variation'
-  | 'Club Premises Certificate (new)'
-  | 'Variation of Club Premises Certificate';
+  | 'Grant of a Premises Licence'
+  | 'Variation of a Premises Licence'
+  | 'Minor Variation of a Premises Licence'
+  | 'Grant of a Club Premises Certificate'
+  | 'Variation of a Club Premises Certificate';
 
 const applicationTypes: ApplicationType[] = [
-  'New Premises Licence',
-  'Variation of Premises Licence',
-  'Minor Variation',
-  'Club Premises Certificate (new)',
-  'Variation of Club Premises Certificate',
+  'Grant of a Premises Licence',
+  'Variation of a Premises Licence',
+  'Minor Variation of a Premises Licence',
+  'Grant of a Club Premises Certificate',
+  'Variation of a Club Premises Certificate',
 ];
 
 const activityOptions = [
-  'Sale of alcohol (on premises)',
-  'Sale of alcohol (off premises)',
-  'Sale of alcohol (on & off)',
-  'Provision of late-night refreshment',
-  'Live music',
-  'Recorded music',
-  'Performance of dance',
-  'Anything of a similar description',
+  'On and Off Sale of Alcohol',
+  'On Sale of Alcohol',
+  'Off Sale of Alcohol',
+  'Provision of Late Night Refreshment',
+  'Live Music',
+  'Recorded Music',
+  'Performance of Dance',
+  'Anything of a Similar Description',
 ];
 
 const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
@@ -39,6 +39,9 @@ interface FormData {
   premisesAddress: string;
   applicantName: string;
   councilName: string;
+  councilPostalAddress: string;
+  councilOfficeHours: string;
+  councilApplicationsUrl: string;
   inspectionMethod: string;
   representationMethod: string;
   representationDeadline: string;
@@ -140,11 +143,14 @@ export function WeeklyHoursInput({
 
 export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) {
   const [form, setForm] = useState<FormData>({
-    applicationType: 'New Premises Licence',
+    applicationType: 'Grant of a Premises Licence',
     premisesName: '',
     premisesAddress: '',
     applicantName: '',
     councilName: '',
+    councilPostalAddress: '',
+    councilOfficeHours: '',
+    councilApplicationsUrl: '',
     inspectionMethod: '',
     representationMethod: '',
     representationDeadline: '',
@@ -166,7 +172,7 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) 
 
   const isClub = form.applicationType.includes('Club');
   const isVariation = form.applicationType.includes('Variation');
-  const alcoholSelected = form.activities.some((a) => a.startsWith('Sale of alcohol'));
+  const alcoholSelected = form.activities.some((a) => a.includes('Sale of Alcohol'));
   const needsDps = alcoholSelected && !isClub;
 
   function toggleActivity(a: string) {
@@ -188,7 +194,13 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) 
     }));
   }
 
-  const noticeText = useMemo(() => generateNotice(form), [form]);
+  const noticeText = useMemo(() => {
+    try {
+      return generateNotice(form);
+    } catch (e) {
+      return (e as Error).message;
+    }
+  }, [form]);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -286,10 +298,48 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef }: Props) 
             Representation deadline
           </label>
           <input
-            type="date"
             id="representationDeadline"
             name="representationDeadline"
             value={form.representationDeadline}
+            onChange={handleChange}
+            className="w-full rounded border border-slate-300 p-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700" htmlFor="councilPostalAddress">
+            Council postal address
+          </label>
+          <input
+            id="councilPostalAddress"
+            name="councilPostalAddress"
+            value={form.councilPostalAddress}
+            onChange={handleChange}
+            className="w-full rounded border border-slate-300 p-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700" htmlFor="councilOfficeHours">
+            Council office hours
+          </label>
+          <input
+            id="councilOfficeHours"
+            name="councilOfficeHours"
+            value={form.councilOfficeHours}
+            onChange={handleChange}
+            className="w-full rounded border border-slate-300 p-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-700" htmlFor="councilApplicationsUrl">
+            Council applications URL
+          </label>
+          <input
+            id="councilApplicationsUrl"
+            name="councilApplicationsUrl"
+            value={form.councilApplicationsUrl}
             onChange={handleChange}
             className="w-full rounded border border-slate-300 p-2"
             required

--- a/src/lib/noticeTemplate.ts
+++ b/src/lib/noticeTemplate.ts
@@ -3,8 +3,39 @@ export interface Hours {
 }
 
 const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-function formatHours(hours: Hours): string {
-  const result: string[] = [];
+
+const template = `Licensing Act 2003
+Notice of Application for the 
+{{HEADING_LINE_3}}
+
+{{APPLICANT_NAME}} gives notice that an application was made to {{COUNCIL_NAME}} for the {{HEADING_LINE_3}} at {{PREMISES_ADDRESS_FULL}} in which the following licensable activities are proposed…
+{{ACTIVITIES_BLOCK}}
+
+The full application, giving details about the proposed licensable activities, has been sent to the Licensing Section, {{COUNCIL_NAME}} and may be inspected, free of charge, at the offices of the council at:
+{{COUNCIL_POSTAL_ADDRESS}}
+between the hours of {{COUNCIL_OFFICE_HOURS}} (or by prior appointment)
+Monday to Friday or
+{{COUNCIL_APPLICATIONS_URL}}
+
+An interested party or Responsible Authority may make representations to the Licensing Section within 28 Consecutive Days of the day the application was made as detailed above, no later than: {{REPRESENTATION_DEADLINE}}
+
+It is an offence to knowingly or recklessly make a false statement in connection with an application and a person may be liable on summary conviction to an unlimited fine.`;
+
+function ensure(value: string, field: string): string {
+  if (!value) throw new Error(`${field} is required`);
+  return value;
+}
+
+function validateTime(value: string, allow24 = false): string {
+  const regex = allow24
+    ? /^(?:([01]\d|2[0-3]):[0-5]\d|24:00)$/
+    : /^([01]\d|2[0-3]):[0-5]\d$/;
+  if (!regex.test(value)) throw new Error(`Invalid time: ${value}`);
+  return value;
+}
+
+function groupHours(hours: Hours) {
+  const groups: { start: string; end: string; days: string[] }[] = [];
   let i = 0;
   while (i < days.length) {
     const day = days[i];
@@ -13,8 +44,8 @@ function formatHours(hours: Hours): string {
       i++;
       continue;
     }
-    const start = h.start;
-    const end = h.end;
+    const start = validateTime(h.start);
+    const end = validateTime(h.end, true);
     let j = i + 1;
     while (
       j < days.length &&
@@ -23,73 +54,86 @@ function formatHours(hours: Hours): string {
     ) {
       j++;
     }
-    const label = i + 1 === j ? days[i] : `${days[i]}–${days[j - 1]}`;
-    result.push(`${label}: ${start}–${end}`);
+    groups.push({ start, end, days: days.slice(i, j) });
     i = j;
   }
-  return result.join('\n');
+  return groups;
 }
 
-function extractAddressAndPostcode(address: string): { address: string; postcode: string } {
-  const match = address.match(/(.*)\b([A-Z]{1,2}\d{1,2}[A-Z]?\s*\d[A-Z]{2})$/i);
-  if (match) {
-    return {
-      address: match[1].trim().replace(/,?$/, ''),
-      postcode: match[2].toUpperCase(),
-    };
+function dayLabel(groupDays: string[]): string {
+  if (groupDays.length === 7) return 'DAILY';
+  if (groupDays.length === 1) return groupDays[0];
+  return `${groupDays[0]}\u2013${groupDays[groupDays.length - 1]}`;
+}
+
+function formatActivities(activities: string[], activityHours: Record<string, Hours>): string {
+  if (!activities || activities.length === 0) {
+    throw new Error('ACTIVITIES_BLOCK is required');
   }
-  return { address, postcode: '' };
-}
-
-function summarizeOpeningHours(hours: Hours): { days: string; start: string; end: string } {
-  const first = hours['Mon'];
-  if (!first?.start || !first?.end) return { days: '', start: '', end: '' };
-  const allSame = days.every((d) => hours[d]?.start === first.start && hours[d]?.end === first.end);
-  if (allSame) {
-    return { days: 'Monday to Sunday', start: first.start, end: first.end };
+  const lines: string[] = [];
+  for (const act of activities) {
+    const hours = activityHours[act];
+    if (!hours) throw new Error(`Hours required for activity: ${act}`);
+    const groups = groupHours(hours);
+    for (const g of groups) {
+      const dLabel = dayLabel(g.days);
+      const hLabel = `${g.start} to ${g.end}`;
+      lines.push(`${act} \u2013 ${hLabel}hrs - ${dLabel}`);
+    }
   }
-  return { days: '', start: '', end: '' };
+  if (lines.length === 0) throw new Error('ACTIVITIES_BLOCK is required');
+  return lines.join('\n');
 }
 
-const template = `Notice of Application for a [APPLICATION_TYPE]
+interface FormInput {
+  applicationType?: string;
+  applicantName?: string;
+  councilName?: string;
+  premisesName?: string;
+  premisesAddress?: string;
+  councilPostalAddress?: string;
+  councilOfficeHours?: string;
+  councilApplicationsUrl?: string;
+  representationDeadline?: string;
+  activities?: string[];
+  activityHours?: Record<string, Hours>;
+}
 
-I, [APPLICANT FULL NAME] Address of Premises: [PREMISES NAME], [PREMISES ADDRESS], [POSTCODE] have made the above application on [APPLICATION DATE] to [COUNCIL NAME] for:
-[LICENSABLE ACTIVITIES AND DESCRIPTION] and opening hours [DAYS] [START TIME] to [END TIME].
-The full application can be viewed at [COUNCIL NAME]. Contact [LICENSING MANAGER / OFFICER], [COUNCIL DEPARTMENT / OFFICE NAME], [COUNCIL OFFICE ADDRESS], between the hours of [VIEWING START TIME] and [VIEWING END TIME] on [VIEWING DAYS], visit [COUNCIL WEBSITE], or email: [COUNCIL LICENSING EMAIL].
-A Responsible Authority or Other Persons may make written representations about this application to the Licensing Office on or before [REPRESENTATION DEADLINE DATE].
-It is an offence, knowingly or recklessly, to make a false statement in connection with an application, and on summary conviction is liable to an unlimited fine.`;
+export function generateNotice(form: FormInput): string {
+  const heading = ensure(form.applicationType || '', 'HEADING_LINE_3');
+  const applicant = ensure(form.applicantName || '', 'APPLICANT_NAME');
+  const council = ensure(form.councilName || '', 'COUNCIL_NAME');
 
-export function generateNotice(form: any): string {
-  const { address, postcode } = extractAddressAndPostcode(form.premisesAddress || '');
-  const activityBlock = (form.activities || [])
-    .map((a: string) => `${a}\n${formatHours(form.activityHours?.[a] || {})}`)
-    .join('\n\n');
-  const opening = summarizeOpeningHours(form.openingHours || {});
+  const address = ensure(form.premisesAddress || '', 'PREMISES_ADDRESS_FULL');
+  if (!/[A-Z]{1,2}\d{1,2}[A-Z]?\s*\d[A-Z]{2}/i.test(address)) {
+    throw new Error('PREMISES_ADDRESS_FULL must include postcode');
+  }
+  const premisesAddressFull = form.premisesName
+    ? `${form.premisesName}, ${address}`
+    : address;
+
+  const activities = formatActivities(form.activities || [], form.activityHours || {});
+
+  const councilPostal = ensure(form.councilPostalAddress || '', 'COUNCIL_POSTAL_ADDRESS');
+  const officeHours = ensure(form.councilOfficeHours || '', 'COUNCIL_OFFICE_HOURS');
+  const applicationsUrl = ensure(form.councilApplicationsUrl || '', 'COUNCIL_APPLICATIONS_URL');
+  const repDeadline = ensure(form.representationDeadline || '', 'REPRESENTATION_DEADLINE');
+
   const replacements: Record<string, string> = {
-    'APPLICATION_TYPE': form.applicationType || '',
-    'APPLICANT FULL NAME': form.applicantName || '',
-    'PREMISES NAME': form.premisesName || '',
-    'PREMISES ADDRESS': address,
-    'POSTCODE': postcode,
-    'APPLICATION DATE': form.applicationDate || new Date().toLocaleDateString('en-GB'),
-    'COUNCIL NAME': form.councilName || '',
-    'LICENSABLE ACTIVITIES AND DESCRIPTION': activityBlock,
-    'DAYS': opening.days,
-    'START TIME': opening.start,
-    'END TIME': opening.end,
-    'LICENSING MANAGER / OFFICER': form.licensingManager || '',
-    'COUNCIL DEPARTMENT / OFFICE NAME': form.councilDepartment || '',
-    'COUNCIL OFFICE ADDRESS': form.councilOfficeAddress || '',
-    'VIEWING START TIME': form.viewingStartTime || '',
-    'VIEWING END TIME': form.viewingEndTime || '',
-    'VIEWING DAYS': form.viewingDays || '',
-    'COUNCIL WEBSITE': form.councilWebsite || '',
-    'COUNCIL LICENSING EMAIL': form.councilLicensingEmail || form.councilEmail || '',
-    'REPRESENTATION DEADLINE DATE': form.representationDeadline || '',
+    HEADING_LINE_3: heading,
+    APPLICANT_NAME: applicant,
+    COUNCIL_NAME: council,
+    PREMISES_ADDRESS_FULL: premisesAddressFull,
+    ACTIVITIES_BLOCK: activities,
+    COUNCIL_POSTAL_ADDRESS: councilPostal,
+    COUNCIL_OFFICE_HOURS: officeHours,
+    COUNCIL_APPLICATIONS_URL: applicationsUrl,
+    REPRESENTATION_DEADLINE: repDeadline,
   };
+
   let text = template;
   for (const [key, value] of Object.entries(replacements)) {
-    text = text.replaceAll(`[${key}]`, value);
+    text = text.replace(`{{${key}}}`, value);
   }
   return text;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: "jsdom",
-    setupFiles: ["./vitest.setup.ts"],
+    environment: "node",
   },
 });


### PR DESCRIPTION
## Summary
- replace premises notice template with Licensing Act 2003 wording and stricter activity/hour formatting
- expand premises form to match new template fields and headings
- switch tests to node environment and cover new activity formatting

## Testing
- `npm test -- src/__tests__/noticeTemplate.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b324cd3e083308aaca0aee86fef50