### PR TITLE
feat: add two-step blue notice upload flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently \"vite\" \"ts-node-dev server/index.ts\"",
     "build": "vite build",
     "lint": "eslint . --ext .ts,.tsx",
     "preview": "vite preview",
@@ -19,7 +19,11 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
-    "@supabase/supabase-js": "^2.46.0"
+    "@supabase/supabase-js": "^2.46.0",
+    "react-dropzone": "*",
+    "multer": "*",
+    "express": "*",
+    "cors": "*"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
@@ -44,6 +48,11 @@
     "@testing-library/user-event": "^14.4.3",
     "@typescript-eslint/parser": "^8.35.1",
     "@typescript-eslint/eslint-plugin": "^8.35.1",
-    "eslint-config-prettier": "^9.1.0"
+    "eslint-config-prettier": "^9.1.0",
+    "@types/multer": "*",
+    "@types/express": "*",
+    "@types/cors": "*",
+    "ts-node-dev": "*",
+    "concurrently": "*"
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import cors from "cors";
+import path from "path";
+import uploadsRouter from "./routes/uploads";
+
+const app = express();
+app.use(cors());
+app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
+app.use("/api/uploads", uploadsRouter);
+
+const port = process.env.PORT || 5174;
+app.listen(port, () => console.log(`API on http://localhost:${port}`));

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import multer from "multer";
+import fs from "fs";
+import path from "path";
+import { uid } from "../../src/lib/utils";
+
+const router = Router();
+const uploadDir = path.join(process.cwd(), "uploads", "blue-notices");
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, uploadDir),
+  filename: (_req, file, cb) => {
+    const safe = file.originalname.replace(/[^a-zA-Z0-9._-]/g, "_");
+    cb(null, `${new Date().toISOString()}-${uid("file")}-${safe}`);
+  },
+});
+const upload = multer({ storage, limits: { fileSize: 15 * 1024 * 1024 } });
+
+router.post("/blue-notice", upload.array("files"), (req, res) => {
+  const files = (req.files as Express.Multer.File[] || []).map((f) => ({
+    id: uid("up"),
+    filename: f.filename,
+    url: `/uploads/blue-notices/${f.filename}`,
+    size: f.size,
+    mime: f.mimetype,
+  }));
+  res.json({ files });
+});
+
+export default router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
 import PublishPage from "./pages/PublishPage";
 import Success from "./pages/Success";
+import DetailsPage from "./pages/DetailsPage";
 
 export default function App() {
   const path = window.location.pathname;
@@ -12,6 +13,8 @@ export default function App() {
       return <PublishPage />;
     case "/success":
       return <Success />;
+    case "/details":
+      return <DetailsPage />;
     default:
       return <Home />;
   }

--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -1,0 +1,58 @@
+import { useState, useCallback } from "react";
+import { useDropzone } from "react-dropzone";
+
+type UploadedMeta = { id: string; filename: string; url: string; size: number; mime: string };
+export default function BlueNoticeUpload({ onUploaded }: { onUploaded: (files: UploadedMeta[]) => void }) {
+  const [status, setStatus] = useState<"idle" | "uploading" | "done" | "error">("idle");
+  const [error, setError] = useState<string>("");
+
+  const onDrop = useCallback(async (accepted: File[]) => {
+    if (!accepted.length) return;
+    setStatus("uploading");
+    setError("");
+    const form = new FormData();
+    accepted.forEach((f) => form.append("files", f));
+    try {
+      const res = await fetch("/api/uploads/blue-notice", { method: "POST", body: form });
+      if (!res.ok) throw new Error(`Upload failed (${res.status})`);
+      const json = await res.json();
+      setStatus("done");
+      onUploaded(json.files);
+    } catch (e: any) {
+      setStatus("error");
+      setError(e?.message || "Upload failed");
+    }
+  }, [onUploaded]);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: true,
+    accept: {
+      "application/pdf": [".pdf"],
+      "application/msword": [".doc"],
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
+      "image/*": [".png", ".jpg", ".jpeg"],
+    },
+    maxSize: 15 * 1024 * 1024,
+  });
+
+  return (
+    <div className="rounded-2xl border bg-gradient-to-br from-white to-slate-50 p-5 shadow-sm">
+      <div className="mb-2 text-lg font-semibold">Already have your blue notice? Upload here</div>
+      <div
+        {...getRootProps({
+          className: `cursor-pointer rounded-xl border-2 border-dashed p-6 text-center ${isDragActive ? "bg-slate-50" : ""}`,
+        })}
+      >
+        <input {...getInputProps()} />
+        <div className="text-sm text-slate-600">
+          <div className="font-medium mb-1">PDF, DOC, DOCX, PNG or JPG (max 15 MB)</div>
+          <div>Drag & drop, or click to choose file(s)</div>
+        </div>
+      </div>
+      {status === "uploading" && <div className="mt-3 text-sm">Uploading…</div>}
+      {status === "done" && <div className="mt-3 text-sm text-emerald-600">Uploaded. Continue below.</div>}
+      {status === "error" && <div className="mt-3 text-sm text-rose-600">{error}</div>}
+    </div>
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,19 @@
+export function uid(prefix = "id"): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 9)}`;
+}
+export function humanDate(iso?: string) {
+  if (!iso) return "";
+  const d = new Date(iso + (iso.includes("T") ? "" : "T00:00:00"));
+  return d.toLocaleDateString(undefined, { weekday: "short", year: "numeric", month: "short", day: "numeric" });
+}
+// Very rough postcode→council heuristic (replace with real lookup later)
+export function inferCouncil(postcode: string | undefined) {
+  if (!postcode) return undefined;
+  const pc = postcode.toUpperCase();
+  if (pc.startsWith("SW")) return "Wandsworth";
+  if (pc.startsWith("SE")) return "Southwark";
+  if (pc.startsWith("L")) return "Liverpool";
+  if (pc.startsWith("M")) return "Manchester";
+  if (pc.startsWith("BN")) return "Brighton & Hove";
+  return undefined;
+}

--- a/src/pages/DetailsPage.tsx
+++ b/src/pages/DetailsPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { NoticeDraft, NoticeType, UploadedFile } from "../types/notice";
+import { uid, inferCouncil } from "../lib/utils";
+
+export default function DetailsPage() {
+  const [files, setFiles] = useState<UploadedFile[]>([]);
+  const [form, setForm] = useState<Partial<NoticeDraft>>({
+    noticeType: "Premises Licence",
+    status: "Draft",
+  } as any);
+
+  useEffect(() => {
+    const raw = localStorage.getItem("blueNoticeUploads");
+    if (raw) setFiles(JSON.parse(raw));
+  }, []);
+
+  function update<K extends keyof NoticeDraft>(k: K, v: any) {
+    setForm((f) => ({ ...f, [k]: v }));
+    if (k === "postcode" && !form.council) {
+      const guess = inferCouncil(v as string);
+      if (guess) setForm((f) => ({ ...f, council: guess }));
+    }
+  }
+
+  function save() {
+    const draft: NoticeDraft = {
+      id: uid("draft"),
+      createdAt: new Date().toISOString(),
+      noticeType: (form.noticeType as NoticeType) || "Premises Licence",
+      applicantName: form.applicantName || "",
+      applicantEmail: form.applicantEmail || "",
+      applicantPhone: form.applicantPhone,
+      premisesName: form.premisesName,
+      premisesAddress: form.premisesAddress || "",
+      postcode: form.postcode || "",
+      council: form.council,
+      consultationStart: form.consultationStart,
+      consultationEnd: form.consultationEnd,
+      blueNoticeUploads: files,
+      status: "Draft",
+    };
+    const existing = JSON.parse(localStorage.getItem("noticeDrafts") || "[]");
+    existing.unshift(draft);
+    localStorage.setItem("noticeDrafts", JSON.stringify(existing));
+    window.location.href = "/success";
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4">
+      <h1 className="text-xl font-semibold">Notice Details</h1>
+
+      <div className="rounded-2xl border p-4">
+        <div className="text-sm text-slate-600 mb-2">Uploaded blue notice</div>
+        {files.length === 0 ? (
+          <div className="text-slate-500 text-sm">No file found (go back and upload)</div>
+        ) : (
+          <ul className="list-disc list-inside text-sm">
+            {files.map((f) => (
+              <li key={f.id}>
+                <a className="underline" href={f.url} target="_blank" rel="noreferrer">
+                  {f.filename}
+                </a>{" "}
+                — {(f.size / 1024).toFixed(1)} KB
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label className="text-sm">Applicant / Company</label>
+          <input className="w-full border rounded p-2" onChange={(e) => update("applicantName", e.target.value)} />
+        </div>
+        <div>
+          <label className="text-sm">Applicant Email</label>
+          <input
+            type="email"
+            className="w-full border rounded p-2"
+            onChange={(e) => update("applicantEmail", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-sm">Applicant Phone (optional)</label>
+          <input className="w-full border rounded p-2" onChange={(e) => update("applicantPhone", e.target.value)} />
+        </div>
+        <div>
+          <label className="text-sm">Notice Type</label>
+          <select className="w-full border rounded p-2" onChange={(e) => update("noticeType", e.target.value)}>
+            {["Premises Licence", "TEN", "Gambling", "Goods Vehicle Operator", "Traffic Order"].map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="text-sm">Premises Name (optional)</label>
+          <input className="w-full border rounded p-2" onChange={(e) => update("premisesName", e.target.value)} />
+        </div>
+        <div className="md:col-span-2">
+          <label className="text-sm">Premises Address</label>
+          <input className="w-full border rounded p-2" onChange={(e) => update("premisesAddress", e.target.value)} />
+        </div>
+        <div>
+          <label className="text-sm">Postcode</label>
+          <input className="w-full border rounded p-2" onChange={(e) => update("postcode", e.target.value)} />
+        </div>
+        <div>
+          <label className="text-sm">Council / Licensing Authority</label>
+          <input
+            className="w-full border rounded p-2"
+            value={form.council || ""}
+            onChange={(e) => update("council", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-sm">Consultation Start</label>
+          <input
+            type="date"
+            className="w-full border rounded p-2"
+            onChange={(e) => update("consultationStart", e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-sm">Consultation End</label>
+          <input
+            type="date"
+            className="w-full border rounded p-2"
+            onChange={(e) => update("consultationEnd", e.target.value)}
+          />
+        </div>
+      </div>
+
+      <button onClick={save} className="rounded-lg bg-black px-4 py-2 text-white">
+        Save & Continue
+      </button>
+    </div>
+  );
+}

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -6,6 +6,7 @@ import GamblingForm from '../components/publish/GamblingForm';
 import Reveal from '../components/publish/Reveal';
 import { supabase } from '../lib/supabase';
 import SiteHeader from '../components/SiteHeader';
+import BlueNoticeUpload from '../components/BlueNoticeUpload';
 
 export default function PublishPage() {
   const [type, setType] = useState<NoticeType | ''>('');
@@ -13,6 +14,11 @@ export default function PublishPage() {
   const [error, setError] = useState('');
   const firstFieldRef = useRef<HTMLInputElement>(null);
   const announceRef = useRef<HTMLDivElement>(null);
+
+  function handleUploaded(files: any[]) {
+    localStorage.setItem('blueNoticeUploads', JSON.stringify(files));
+    window.location.href = '/details';
+  }
 
   useEffect(() => {
     if (type && firstFieldRef.current) firstFieldRef.current.focus();
@@ -62,6 +68,7 @@ export default function PublishPage() {
       <main className="flex-1 flex items-start justify-center py-10 px-4">
         <div className="w-full max-w-xl bg-white/95 rounded-2xl ring-1 ring-slate-200 shadow p-6">
           <h1 className="text-2xl font-semibold mb-4">Publish a Notice</h1>
+          <BlueNoticeUpload onUploaded={handleUploaded} />
           <NoticeTypeSelect value={type} onChange={setType} />
           <div ref={announceRef} aria-live="polite" className="sr-only" />
           <Reveal show={type === 'premises'}>

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,0 +1,33 @@
+export type NoticeType =
+  | "Premises Licence"
+  | "TEN"
+  | "Gambling"
+  | "Goods Vehicle Operator"
+  | "Traffic Order";
+
+export type UploadedFile = {
+  id: string;
+  filename: string;
+  url: string;
+  size: number;
+  mime: string;
+};
+
+export type NoticeDraft = {
+  id: string;
+  createdAt: string;
+  noticeType: NoticeType;
+  applicantName: string;
+  applicantEmail: string;
+  applicantPhone?: string;
+  premisesName?: string;
+  premisesAddress: string;
+  postcode: string;
+  council?: string;
+  consultationStart?: string; // yyyy-mm-dd
+  consultationEnd?: string;   // yyyy-mm-dd
+  blueNoticeUploads: UploadedFile[];
+  newspaperProofUploads?: UploadedFile[];
+  additionalDocs?: UploadedFile[];
+  status: "Draft" | "Submitted";
+};


### PR DESCRIPTION
## Summary
- add express upload API and static serving
- implement BlueNoticeUpload component and details form
- wire publish page and routing for upload flow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run dev` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af044855108330ba1363804c109786