### PR TITLE
Add address autocomplete and email notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dropzone": "*",
     "multer": "*",
     "express": "*",
-    "cors": "*"
+    "cors": "*",
+    "lodash.debounce": "^4.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,10 +2,13 @@ import express from "express";
 import cors from "cors";
 import path from "path";
 import { fileURLToPath } from "url";
+import notifyRouter from "./routes/notify.js";
 
 const app = express();
 app.use(cors());
 app.use(express.json());
+
+app.use("/api/notify", notifyRouter);
 
 // Static serving for uploads in dev
 const __filename = fileURLToPath(import.meta.url);

--- a/server/routes/notify.ts
+++ b/server/routes/notify.ts
@@ -1,0 +1,49 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.post("/notice-saved", async (req, res) => {
+  try {
+    const { applicantEmail, councilEmail, draftId, uploads } = req.body || {};
+    if (!applicantEmail) return res.status(400).json({ error: "Missing applicantEmail" });
+    const key = process.env.RESEND_API_KEY;
+    if (!key) return res.status(500).json({ error: "Missing RESEND_API_KEY" });
+
+    const subject = `Notice saved (draft ${draftId})`;
+    const html = `
+      <div style="font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;padding:12px">
+        <h2>Notice saved</h2>
+        <p>Your notice has been saved as a draft.</p>
+        ${Array.isArray(uploads) && uploads.length ? `
+          <p><strong>Files:</strong></p>
+          <ul>${uploads.map((u: any) => `<li><a href="${u.url}">${u.filename}</a></li>`).join("")}</ul>
+        ` : ""}
+        <p>You can return to the portal to complete submission.</p>
+      </div>
+    `;
+
+    const toList = [applicantEmail, councilEmail].filter(Boolean);
+    const resp = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        from: "Public Notice Portal <no-reply@notices.example>",
+        to: toList,
+        subject,
+        html,
+      }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      return res.status(500).json({ error: `Resend error ${resp.status}: ${text}` });
+    }
+    return res.json({ ok: true });
+  } catch (e: any) {
+    return res.status(500).json({ error: e?.message || "Server error" });
+  }
+});
+
+export default router;

--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -1,0 +1,104 @@
+import { useState, useMemo } from "react";
+import debounce from "lodash.debounce";
+
+export type StructuredAddress = {
+  line1: string;
+  line2?: string;
+  city?: string;
+  county?: string;
+  postcode?: string;
+};
+
+export default function AddressAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  placeholder = "Start typing an address…",
+}: {
+  value?: string;
+  onChange: (v: string) => void;
+  onSelect: (addr: StructuredAddress) => void;
+  placeholder?: string;
+}) {
+  const [suggestions, setSuggestions] = useState<any[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const runSearch = async (q: string) => {
+    if (!q || q.length < 3) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const provider = import.meta.env.VITE_ADDRESS_PROVIDER || "nominatim";
+      const url =
+        provider === "nominatim"
+          ? `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&q=${encodeURIComponent(q)}`
+          : `https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&q=${encodeURIComponent(q)}`;
+      const res = await fetch(url, { headers: { Accept: "application/json" } });
+      const json = await res.json();
+      setSuggestions(json.slice(0, 8));
+      setOpen(true);
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const debounced = useMemo(() => debounce(runSearch, 300), []);
+
+  return (
+    <div className="relative">
+      <input
+        className="w-full border rounded p-2"
+        value={value || ""}
+        placeholder={placeholder}
+        onChange={(e) => {
+          onChange(e.target.value);
+          debounced(e.target.value);
+        }}
+        onFocus={() => {
+          if (suggestions.length) setOpen(true);
+        }}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+      />
+      {loading && <div className="mt-1 text-xs text-slate-500">Searching…</div>}
+      {open && suggestions.length > 0 && (
+        <div className="absolute z-10 mt-1 w-full rounded border bg-white shadow">
+          {suggestions.map((s) => {
+            const a = s.address || {};
+            const postcode = a.postcode || "";
+            const line1 = [a.house_number, a.road].filter(Boolean).join(" ");
+            const city = a.city || a.town || a.village || a.hamlet || a.suburb;
+            const county = a.state || a.county;
+            const display = [line1 || s.display_name.split(",")[0], city, postcode]
+              .filter(Boolean)
+              .join(", ");
+            return (
+              <button
+                key={s.place_id}
+                type="button"
+                className="block w-full text-left px-3 py-2 hover:bg-slate-50"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onSelect({
+                    line1: line1 || s.display_name,
+                    city,
+                    county,
+                    postcode,
+                  });
+                  setOpen(false);
+                }}
+              >
+                {display}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -88,6 +88,9 @@ export default function BlueNoticeUpload({ onUploaded }: { onUploaded: (files: U
           <div>Drag & drop, or click to choose file(s)</div>
         </div>
       </div>
+      <p className="mt-2 text-xs text-slate-500">
+        After upload, you’ll see a preview below. Please check your notice for any mistakes.
+      </p>
       {status === "uploading" && <div className="mt-3 text-sm">Uploading…</div>}
       {status === "done" && <div className="mt-3 text-sm text-emerald-600">Uploaded. Redirecting…</div>}
       {status === "error" && <div className="mt-3 text-sm text-rose-600">{error}</div>}

--- a/src/pages/DetailsPage.tsx
+++ b/src/pages/DetailsPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
+import AddressAutocomplete, { StructuredAddress } from "../components/AddressAutocomplete";
 import { NoticeDraft, NoticeType, UploadedFile } from "../types/notice";
 import { uid, inferCouncil } from "../lib/utils";
-
 export default function DetailsPage() {
   const [files, setFiles] = useState<UploadedFile[]>([]);
+  const [addrSearch, setAddrSearch] = useState("");
   const [form, setForm] = useState<Partial<NoticeDraft>>({
     noticeType: "Premises Licence",
     status: "Draft",
@@ -16,24 +17,45 @@ export default function DetailsPage() {
 
   function update<K extends keyof NoticeDraft>(k: K, v: any) {
     setForm((f) => ({ ...f, [k]: v }));
-    if (k === "postcode" && !form.council) {
-      const guess = inferCouncil(v as string);
-      if (guess) setForm((f) => ({ ...f, council: guess }));
+    if (k === "postcode") {
+      const guess = inferCouncil(String(v));
+      if (guess && !form.council) setForm((f) => ({ ...f, council: guess }));
     }
   }
 
-  function save() {
+  function onAddressSelect(a: StructuredAddress) {
+    setAddrSearch([a.line1, a.city].filter(Boolean).join(", "));
+    update("premisesAddress", a.line1 + (a.city ? `, ${a.city}` : ""));
+    if (a.postcode) update("postcode", a.postcode);
+  }
+
+  async function save() {
+    const required = [
+      "applicantName",
+      "applicantEmail",
+      "premisesAddress",
+      "postcode",
+      "noticeType",
+      "councilEmail",
+    ] as const;
+    for (const f of required) {
+      if (!(form as any)[f]) {
+        alert(`Please fill ${f}`);
+        return;
+      }
+    }
     const draft: NoticeDraft = {
       id: uid("draft"),
       createdAt: new Date().toISOString(),
       noticeType: (form.noticeType as NoticeType) || "Premises Licence",
-      applicantName: form.applicantName || "",
-      applicantEmail: form.applicantEmail || "",
+      applicantName: form.applicantName!,
+      applicantEmail: form.applicantEmail!,
       applicantPhone: form.applicantPhone,
       premisesName: form.premisesName,
-      premisesAddress: form.premisesAddress || "",
-      postcode: form.postcode || "",
+      premisesAddress: form.premisesAddress!,
+      postcode: form.postcode!,
       council: form.council,
+      councilEmail: (form as any).councilEmail,
       consultationStart: form.consultationStart,
       consultationEnd: form.consultationEnd,
       blueNoticeUploads: files,
@@ -42,35 +64,72 @@ export default function DetailsPage() {
     const existing = JSON.parse(localStorage.getItem("noticeDrafts") || "[]");
     existing.unshift(draft);
     localStorage.setItem("noticeDrafts", JSON.stringify(existing));
-    window.location.href = "/success";
+
+    try {
+      await fetch("/api/notify/notice-saved", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          applicantEmail: draft.applicantEmail,
+          councilEmail: draft.councilEmail,
+          draftId: draft.id,
+          uploads: draft.blueNoticeUploads,
+        }),
+      });
+    } catch {
+      // ignore
+    }
+
+    window.location.assign("/success");
   }
 
   return (
     <div className="mx-auto max-w-3xl space-y-4 p-4">
       <h1 className="text-xl font-semibold">Notice Details</h1>
 
+      {/* Uploaded preview */}
       <div className="rounded-2xl border p-4">
         <div className="text-sm text-slate-600 mb-2">Uploaded blue notice</div>
         {files.length === 0 ? (
           <div className="text-slate-500 text-sm">No file found (go back and upload)</div>
         ) : (
-          <ul className="list-disc list-inside text-sm">
+          <div className="space-y-3">
+            <div className="rounded bg-amber-50 text-amber-900 p-2 text-sm">
+              Please review your notice below for any mistakes.
+            </div>
             {files.map((f) => (
-              <li key={f.id}>
-                <a className="underline" href={f.url} target="_blank" rel="noreferrer">
-                  {f.filename}
-                </a>{" "}
-                — {(f.size / 1024).toFixed(1)} KB
-              </li>
+              <div key={f.id} className="space-y-2">
+                <div className="text-sm">
+                  {f.filename} — {(f.size / 1024).toFixed(1)} KB
+                </div>
+                {f.mime?.startsWith("image/") ? (
+                  <img src={f.url} alt={f.filename} className="max-h-96 rounded border" />
+                ) : f.mime === "application/pdf" || f.filename.toLowerCase().endsWith(".pdf") ? (
+                  <iframe src={f.url} className="w-full h-[480px] rounded border" />
+                ) : (
+                  <a
+                    href={f.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline text-blue-600"
+                  >
+                    View file
+                  </a>
+                )}
+              </div>
             ))}
-          </ul>
+          </div>
         )}
       </div>
 
+      {/* Form */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div>
           <label className="text-sm">Applicant / Company</label>
-          <input className="w-full border rounded p-2" onChange={(e) => update("applicantName", e.target.value)} />
+          <input
+            className="w-full border rounded p-2"
+            onChange={(e) => update("applicantName", e.target.value)}
+          />
         </div>
         <div>
           <label className="text-sm">Applicant Email</label>
@@ -82,11 +141,17 @@ export default function DetailsPage() {
         </div>
         <div>
           <label className="text-sm">Applicant Phone (optional)</label>
-          <input className="w-full border rounded p-2" onChange={(e) => update("applicantPhone", e.target.value)} />
+          <input
+            className="w-full border rounded p-2"
+            onChange={(e) => update("applicantPhone", e.target.value)}
+          />
         </div>
         <div>
           <label className="text-sm">Notice Type</label>
-          <select className="w-full border rounded p-2" onChange={(e) => update("noticeType", e.target.value)}>
+          <select
+            className="w-full border rounded p-2"
+            onChange={(e) => update("noticeType", e.target.value)}
+          >
             {["Premises Licence", "TEN", "Gambling", "Goods Vehicle Operator", "Traffic Order"].map((t) => (
               <option key={t} value={t}>
                 {t}
@@ -96,15 +161,32 @@ export default function DetailsPage() {
         </div>
         <div>
           <label className="text-sm">Premises Name (optional)</label>
-          <input className="w-full border rounded p-2" onChange={(e) => update("premisesName", e.target.value)} />
+          <input
+            className="w-full border rounded p-2"
+            onChange={(e) => update("premisesName", e.target.value)}
+          />
         </div>
         <div className="md:col-span-2">
-          <label className="text-sm">Premises Address</label>
-          <input className="w-full border rounded p-2" onChange={(e) => update("premisesAddress", e.target.value)} />
+          <label className="text-sm">Premises address</label>
+          <AddressAutocomplete
+            value={addrSearch}
+            onChange={setAddrSearch}
+            onSelect={onAddressSelect}
+          />
+          <input
+            className="mt-2 w-full border rounded p-2"
+            placeholder="Address line (editable)"
+            value={form.premisesAddress || ""}
+            onChange={(e) => update("premisesAddress", e.target.value)}
+          />
         </div>
         <div>
           <label className="text-sm">Postcode</label>
-          <input className="w-full border rounded p-2" onChange={(e) => update("postcode", e.target.value)} />
+          <input
+            className="w-full border rounded p-2"
+            value={form.postcode || ""}
+            onChange={(e) => update("postcode", e.target.value)}
+          />
         </div>
         <div>
           <label className="text-sm">Council / Licensing Authority</label>
@@ -113,6 +195,22 @@ export default function DetailsPage() {
             value={form.council || ""}
             onChange={(e) => update("council", e.target.value)}
           />
+        </div>
+        <div className="md:col-span-2">
+          <label className="text-sm">Council email (required)</label>
+          <input
+            type="email"
+            className="w-full border rounded p-2"
+            placeholder="e.g. licensing@council.gov.uk"
+            onChange={(e) => (update as any)("councilEmail", e.target.value)}
+          />
+          {form.postcode && form.council && (
+            <div className="text-xs text-slate-500 mt-1">
+              Tip: try licensing@
+              {String(form.council).toLowerCase().replace(/\s+/g, "")}.
+              gov.uk (edit if different).
+            </div>
+          )}
         </div>
         <div>
           <label className="text-sm">Consultation Start</label>

--- a/src/shims/lodash.debounce.ts
+++ b/src/shims/lodash.debounce.ts
@@ -1,0 +1,9 @@
+export default function debounce<T extends (...args: any[]) => void>(fn: T, wait = 0) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  return (...args: Parameters<T>): void => {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      fn(...args);
+    }, wait);
+  };
+}

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -24,6 +24,7 @@ export type NoticeDraft = {
   premisesAddress: string;
   postcode: string;
   council?: string;
+  councilEmail?: string;
   consultationStart?: string; // yyyy-mm-dd
   consultationEnd?: string;   // yyyy-mm-dd
   blueNoticeUploads: UploadedFile[];

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "lodash.debounce": ["src/shims/lodash.debounce.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "lodash.debounce": ["src/shims/lodash.debounce.ts"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- add debounced address autocomplete component using Nominatim
- require council email and inline file previews on the details page
- send notification emails for saved drafts via new Express route

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68af298a655c8330bd92931df1c3444e