### PR TITLE
Add notice composer and address normalization utilities

### DIFF
--- a/server/__tests__/addressProvider.test.ts
+++ b/server/__tests__/addressProvider.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOsPlaces, normalizeGetAddress, normalizeMapbox } from "../services/addressProvider";
+
+describe("address normalizers", () => {
+  it("normalizes OS Places record", () => {
+    const raw = {
+      DPA: {
+        UPRN: "123",
+        ADDRESS: "10 Downing Street, London, SW1A 2AA",
+        BUILDING_NUMBER: "10",
+        THOROUGHFARE_NAME: "Downing Street",
+        POST_TOWN: "London",
+        POSTCODE: "SW1A 2AA",
+      },
+    };
+    const result = normalizeOsPlaces(raw);
+    expect(result).toEqual({
+      id: "123",
+      label: "10 Downing Street, London, SW1A 2AA",
+      line1: "10 Downing Street",
+      line2: undefined,
+      city: "London",
+      postcode: "SW1A 2AA",
+    });
+  });
+
+  it("normalizes getaddress.io record", () => {
+    const raw = {
+      id: "GB|12345",
+      address: ["10 Downing Street", "Westminster", "London", "SW1A 2AA"],
+    };
+    const result = normalizeGetAddress(raw);
+    expect(result).toEqual({
+      id: "GB|12345",
+      label: "10 Downing Street, Westminster, London, SW1A 2AA",
+      line1: "10 Downing Street",
+      line2: "Westminster",
+      line3: "London",
+      city: "London",
+      postcode: "SW1A 2AA",
+    });
+  });
+
+  it("normalizes Mapbox feature", () => {
+    const raw = {
+      id: "place.123",
+      address: "10",
+      text: "Downing Street",
+      place_name: "10 Downing Street, London SW1A 2AA, United Kingdom",
+      context: [
+        { id: "postcode.123", text: "SW1A 2AA" },
+        { id: "place.456", text: "London" },
+      ],
+    };
+    const result = normalizeMapbox(raw);
+    expect(result).toEqual({
+      id: "place.123",
+      label: "10 Downing Street, London SW1A 2AA, United Kingdom",
+      line1: "10 Downing Street",
+      line2: undefined,
+      city: "London",
+      postcode: "SW1A 2AA",
+    });
+  });
+});

--- a/server/services/addressProvider.ts
+++ b/server/services/addressProvider.ts
@@ -1,0 +1,76 @@
+export type AddressOption = {
+  id: string;
+  label: string;
+  line1: string;
+  line2?: string;
+  line3?: string;
+  city: string;
+  postcode: string;
+};
+
+/** Normalise an OS Places API record. */
+export function normalizeOsPlaces(raw: any): AddressOption {
+  const d = raw.DPA || {};
+  const line1 = [d.BUILDING_NUMBER, d.THOROUGHFARE_NAME]
+    .filter(Boolean)
+    .join(" ");
+  const line2 = d.DEPENDENT_LOCALITY || d.DOUBLE_DEPENDENT_LOCALITY || undefined;
+  const city = d.POST_TOWN || "";
+  const postcode = d.POSTCODE || "";
+  const label = d.ADDRESS || [line1, city, postcode].filter(Boolean).join(", ");
+  return {
+    id: d.UPRN?.toString() || crypto.randomUUID(),
+    label,
+    line1,
+    line2,
+    city,
+    postcode,
+  };
+}
+
+/** Normalise a getaddress.io record. */
+export function normalizeGetAddress(raw: { id: string; address: string[] }): AddressOption {
+  const parts = (raw.address || []).filter(Boolean);
+  const line1 = parts[0] || "";
+  const line2 = parts[1];
+  const line3 = parts[2];
+  const postcode = parts[parts.length - 1] || "";
+  const city = parts[parts.length - 2] || "";
+  const label = parts.join(", ");
+  return {
+    id: raw.id,
+    label,
+    line1,
+    line2,
+    line3,
+    city,
+    postcode,
+  };
+}
+
+/** Normalise a Mapbox geocoding feature. */
+export function normalizeMapbox(raw: any): AddressOption {
+  const line1 = [raw.address, raw.text].filter(Boolean).join(" ");
+  const context = raw.context || [];
+  const postcode = context.find((c: any) => c.id?.startsWith("postcode"))?.text || "";
+  const city =
+    context.find((c: any) => c.id?.startsWith("place"))?.text ||
+    context.find((c: any) => c.id?.startsWith("locality"))?.text ||
+    context.find((c: any) => c.id?.startsWith("district"))?.text ||
+    "";
+  const line2 = context.find((c: any) => c.id?.startsWith("neighborhood"))?.text;
+  const label = raw.place_name || [line1, city, postcode].filter(Boolean).join(", ");
+  return {
+    id: raw.id,
+    label,
+    line1,
+    line2,
+    city,
+    postcode,
+  };
+}
+
+/** Mock provider just echoes the object. */
+export function normalizeMock(raw: AddressOption): AddressOption {
+  return raw;
+}

--- a/src/__tests__/composePremisesNotice.test.ts
+++ b/src/__tests__/composePremisesNotice.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { composePremisesNotice, Builder, Hours } from "../utils/composePremisesNotice";
+
+describe("composePremisesNotice", () => {
+  const base: Builder = {
+    appType: "new",
+    premisesName: "The Test Pub",
+    premisesAddress: {
+      line1: "1 High St",
+      city: "Testville",
+      postcode: "AB1 2CD",
+    },
+    activities: ["sale of alcohol"],
+    openingHours: {
+      Mon: "10:00-22:00",
+      Tue: "10:00-22:00",
+      Wed: "10:00-22:00",
+      Thu: "10:00-22:00",
+      Fri: "10:00-23:00",
+      Sat: "10:00-23:00",
+      Sun: "12:00-22:00",
+    },
+    repDeadline: "2025-01-01",
+  };
+
+  it("produces a basic notice", () => {
+    const text = composePremisesNotice(base);
+    expect(text).toContain("APPLICATION FOR A NEW PREMISES LICENCE");
+    expect(text).toContain("The Test Pub has applied to the Licensing Authority");
+    expect(text).toContain("sale of alcohol");
+  });
+
+  it("includes optional fields when provided", () => {
+    const b: Builder = {
+      ...base,
+      alcoholHours: base.openingHours,
+      seasonal: "Closed on Christmas Day",
+      dps: "Jane Doe",
+      howToRep: "Email licensing@test.gov",
+    };
+    const text = composePremisesNotice(b);
+    expect(text).toContain("Hours for the sale of alcohol");
+    expect(text).toContain("Seasonal variations: Closed on Christmas Day");
+    expect(text).toContain("Designated premises supervisor: Jane Doe");
+    expect(text).toContain("Email licensing@test.gov");
+  });
+});

--- a/src/utils/composePremisesNotice.ts
+++ b/src/utils/composePremisesNotice.ts
@@ -1,0 +1,77 @@
+export type Day = "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat" | "Sun";
+
+export type Hours = Record<Day, string>;
+
+export type Builder = {
+  appType: "new" | "variation" | "review";
+  premisesName: string;
+  premisesAddress: {
+    line1: string;
+    line2?: string;
+    line3?: string;
+    city: string;
+    postcode: string;
+  };
+  activities: string[];
+  openingHours: Hours;
+  alcoholHours?: Hours;
+  seasonal?: string;
+  dps?: string;
+  howToRep?: string;
+  repDeadline: string; // ISO date string
+  locality?: string;
+};
+
+const days: Day[] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const fmtHours = (h: Hours): string =>
+  days.map((d) => `${d}: ${h[d] || "Closed"}`).join("; ");
+
+/** Compose a Licensing Act premises notice from structured details. */
+export function composePremisesNotice(b: Builder): string {
+  const addr = [
+    b.premisesAddress.line1,
+    b.premisesAddress.line2,
+    b.premisesAddress.line3,
+    b.premisesAddress.city,
+    b.premisesAddress.postcode,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  const activities = b.activities.join("; ");
+  const open = fmtHours(b.openingHours);
+  const alcohol = b.alcoholHours
+    ? `Hours for the sale of alcohol: ${fmtHours(b.alcoholHours)}.\n`
+    : "";
+  const seasonal = b.seasonal ? `Seasonal variations: ${b.seasonal}.\n` : "";
+  const dps = b.dps ? `Designated premises supervisor: ${b.dps}.\n` : "";
+
+  const head =
+    b.appType === "new"
+      ? "LICENSING ACT 2003 – APPLICATION FOR A NEW PREMISES LICENCE"
+      : b.appType === "variation"
+      ? "LICENSING ACT 2003 – APPLICATION TO VARY A PREMISES LICENCE"
+      : "LICENSING ACT 2003 – REVIEW OF PREMISES LICENCE";
+
+  return `${head}
+
+Notice is hereby given that ${b.premisesName} has applied to the Licensing Authority for ${
+    b.appType === "new"
+      ? "a new"
+      : b.appType === "variation"
+      ? "a variation of a"
+      : "a review of a"
+  } premises licence at: ${addr}.
+
+Proposed licensable activities: ${activities}.
+Opening hours of the premises: ${open}.
+${alcohol}${seasonal}${dps}Any person wishing to make representations must do so in writing by ${b.repDeadline}.
+${
+    b.howToRep ||
+    "Representations should be sent to the Licensing Team at the relevant Council. Please note it is an offence to knowingly or recklessly make a false statement in connection with an application (maximum fine on summary conviction unlimited)."
+  }
+This notice is for information only.`;
+}
+
+export default composePremisesNotice;


### PR DESCRIPTION
## Summary
- add composePremisesNotice utility to build Licensing Act notices from structured form data
- introduce address provider normalizers for OS Places, getaddress.io and Mapbox
- cover composer and normalizers with unit tests

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install --no-audit --progress=false` *(fails: 403 Forbidden - lodash.debounce)*

------
https://chatgpt.com/codex/tasks/task_e_68b6df787b948330b8507dd440ddabc2