### PR TITLE
feat: upload blue notice to supabase storage

### DIFF
--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -1,39 +1,95 @@
 import React, { useState, useCallback } from "react";
 import { useDropzone } from "react-dropzone";
+import { uploadBlueNotice } from "../lib/storage";
+
+interface UploadedFile {
+  name: string;
+  size: number;
+  type: string;
+  path: string;
+  publicUrl: string;
+}
 
 interface Props {
   value: string;
   onChange: (v: string) => void;
   onOcrComplete: (text: string, meta: any) => void;
   engine?: string;
+  onUploaded?: (files: UploadedFile[]) => void;
 }
 
-export default function BlueNoticeUpload({ value, onChange, onOcrComplete, engine }: Props) {
+const ACCEPTED_TYPES = ["application/pdf", "image/png", "image/jpeg"];
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+
+export default function BlueNoticeUpload({
+  value,
+  onChange,
+  onOcrComplete,
+  engine,
+  onUploaded,
+}: Props) {
   const [status, setStatus] = useState<"idle" | "uploading" | "error">("idle");
   const [error, setError] = useState("");
+  const [currentFile, setCurrentFile] = useState<File | null>(null);
 
   const onDrop = useCallback(
     async (accepted: File[]) => {
       if (!accepted.length) return;
-      setStatus("uploading");
+      const file = accepted[0];
+      setCurrentFile(file);
       setError("");
-      const fd = new FormData();
-      fd.append("file", accepted[0]);
+
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        setStatus("error");
+        setError("Unsupported file type");
+        return;
+      }
+      if (file.size > MAX_SIZE) {
+        setStatus("error");
+        setError("File must be 10 MB or less");
+        return;
+      }
+
+      setStatus("uploading");
       try {
+        const { path, publicUrl } = await uploadBlueNotice(file);
+        onUploaded?.([
+          { name: file.name, size: file.size, type: file.type, path, publicUrl },
+        ]);
+
+        const fd = new FormData();
+        fd.append("file", file);
         const res = await fetch("/api/upload/ocr", { method: "POST", body: fd });
         const json = await res.json();
         onOcrComplete(json.text || "", json.meta || {});
         onChange(json.text || "");
         setStatus("idle");
       } catch (e: any) {
-        setError("Upload failed");
+        console.error(e);
+        console.error({
+          env: {
+            hasUrl: !!import.meta.env.VITE_SUPABASE_URL,
+            hasKey: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
+          },
+          bucket: "blue-notices",
+          file: { name: file.name, size: file.size, type: file.type },
+        });
+        setError(e.message);
         setStatus("error");
       }
     },
-    [onChange, onOcrComplete]
+    [onChange, onOcrComplete, onUploaded]
   );
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, multiple: false });
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: false,
+    accept: {
+      "application/pdf": [".pdf"],
+      "image/png": [".png"],
+      "image/jpeg": [".jpg", ".jpeg"],
+    },
+  });
 
   const wordCount = value ? value.trim().split(/\s+/).filter(Boolean).length : 0;
 
@@ -46,11 +102,13 @@ export default function BlueNoticeUpload({ value, onChange, onOcrComplete, engin
       >
         <input {...getInputProps()} />
         <div className="text-sm text-slate-600">
-          <div className="font-medium mb-1">PDF, DOC, DOCX, PNG or JPG</div>
+          <div className="font-medium mb-1">PDF, PNG or JPG</div>
           <div>Drag & drop, or click to choose file</div>
         </div>
       </div>
-      {status === "uploading" && <div className="mt-2 text-sm">Processing…</div>}
+      {status === "uploading" && currentFile && (
+        <div className="mt-2 text-sm">Uploading {currentFile.name}…</div>
+      )}
       {status === "error" && <div className="mt-2 text-sm text-rose-600">{error}</div>}
       <textarea
         data-testid="notice-editor"

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,49 @@
+import { supabase } from "./supabase";
+
+const BUCKET = "blue-notices" as const;
+
+export interface UploadResult {
+  path: string;
+  publicUrl: string;
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+}
+
+export async function uploadBlueNotice(file: File): Promise<UploadResult> {
+  try {
+    const uuid = crypto.randomUUID();
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(now.getUTCDate()).padStart(2, "0");
+    const slug = slugify(file.name);
+    const objectPath = `${year}/${month}/${day}/${uuid}-${slug}`;
+
+    const { error } = await supabase.storage
+      .from(BUCKET)
+      .upload(objectPath, file, { upsert: false, contentType: file.type });
+
+    if (error) {
+      throw error;
+    }
+
+    const { data } = supabase.storage.from(BUCKET).getPublicUrl(objectPath);
+    return { path: `${BUCKET}/${objectPath}`, publicUrl: data.publicUrl };
+  } catch (error) {
+    console.error("uploadBlueNotice failed", {
+      error,
+      env: {
+        hasUrl: !!import.meta.env.VITE_SUPABASE_URL,
+        hasKey: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
+      },
+      bucket: BUCKET,
+      file: { name: file.name, size: file.size, type: file.type },
+    });
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
-const url = import.meta.env.VITE_SUPABASE_URL as string;
-const key = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const key = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+if (!url) {
+  throw new Error("VITE_SUPABASE_URL is not set");
+}
+
+if (!key) {
+  throw new Error("VITE_SUPABASE_ANON_KEY is not set");
+}
+
 export const supabase = createClient(url, key, { auth: { persistSession: false } });


### PR DESCRIPTION
## Summary
- add helper to upload to `blue-notices` bucket and return public URL
- refactor BlueNoticeUpload to use helper with validation and progress
- guard against missing Supabase env vars

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b71b2e73b88330ac29d6e8986679cf