### PR TITLE
feat: add doc support and robust OCR upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "pdf-parse": "*",
     "tesseract.js": "*",
     "sharp": "*",
-    "file-type": "*"
+    "file-type": "*",
+    "busboy": "*",
+    "textract": "*"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,12 +3,14 @@ import cors from "cors";
 import path from "path";
 import { fileURLToPath } from "url";
 import notifyRouter from "./routes/notify.js";
+import { ocrUpload } from "./routes/ocr.js";
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
 app.use("/api/notify", notifyRouter);
+app.post("/api/upload/ocr", ocrUpload);
 
 // Static serving for uploads in dev
 const __filename = fileURLToPath(import.meta.url);

--- a/server/routes/ocr.ts
+++ b/server/routes/ocr.ts
@@ -1,0 +1,105 @@
+import type { Request, Response } from "express";
+import busboy from "busboy";
+import pdfParse from "pdf-parse";
+import mammoth from "mammoth";
+import textract from "textract";
+import Tesseract from "tesseract.js";
+import path from "path";
+
+function mimeFromExt(ext: string): string {
+  switch (ext) {
+    case ".pdf":
+      return "application/pdf";
+    case ".doc":
+      return "application/msword";
+    case ".docx":
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    case ".rtf":
+      return "application/rtf";
+    case ".txt":
+      return "text/plain";
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+async function extractText(buffer: Buffer, filename: string, mimeType: string) {
+  const ext = path.extname(filename).toLowerCase();
+  const type = mimeType || mimeFromExt(ext);
+  if (type === "application/pdf" || ext === ".pdf") {
+    const data = await pdfParse(buffer);
+    return data.text;
+  }
+  if (
+    type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+    ext === ".docx"
+  ) {
+    const data = await mammoth.extractRawText({ buffer });
+    return data.value;
+  }
+  if (
+    type === "application/msword" ||
+    ext === ".doc" ||
+    type === "application/rtf" ||
+    ext === ".rtf" ||
+    type === "text/plain" ||
+    ext === ".txt"
+  ) {
+    return await new Promise<string>((resolve, reject) => {
+      textract.fromBufferWithMime(type, buffer, (err, text) => {
+        if (err) reject(err);
+        else resolve(text);
+      });
+    });
+  }
+  if (type.startsWith("image/") || [".png", ".jpg", ".jpeg"].includes(ext)) {
+    const result = await Tesseract.recognize(buffer, "eng");
+    return result.data.text;
+  }
+  return await new Promise<string>((resolve, reject) => {
+    textract.fromBufferWithMime(type, buffer, (err, text) => {
+      if (err) reject(err);
+      else resolve(text);
+    });
+  });
+}
+
+export function ocrUpload(req: Request, res: Response) {
+  const bb = busboy({ headers: req.headers });
+  let fileBuffer: Buffer = Buffer.alloc(0);
+  let filename = "";
+  let mimeType = "";
+
+  bb.on("file", (_name, file, info) => {
+    filename = info.filename;
+    mimeType = info.mimeType;
+    file.on("data", (data: Buffer) => {
+      fileBuffer = Buffer.concat([fileBuffer, data]);
+    });
+  });
+
+  bb.on("error", (err) => {
+    console.error(err);
+    res.status(500).json({ text: "", meta: { error: String(err) } });
+  });
+
+  bb.on("finish", async () => {
+    if (!fileBuffer.length) {
+      return res.status(400).json({ text: "", meta: { error: "No file uploaded" } });
+    }
+    try {
+      const text = await extractText(fileBuffer, filename, mimeType);
+      res.json({ text: text.trim(), meta: { filename, mimeType } });
+    } catch (err: any) {
+      console.error(err);
+      res.status(400).json({ text: "", meta: { error: err?.message || String(err) } });
+    }
+  });
+
+  req.pipe(bb);
+}

--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -18,8 +18,33 @@ interface Props {
   onUploaded?: (files: UploadedFile[]) => void;
 }
 
-const ACCEPTED_TYPES = ["application/pdf", "image/png", "image/jpeg"];
+const ACCEPTED_MIME_TYPES = [
+  "application/pdf",
+  "image/png",
+  "image/jpeg",
+  "text/plain",
+  "application/rtf",
+  "text/rtf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+const ACCEPTED_EXTENSIONS = [
+  ".pdf",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".txt",
+  ".rtf",
+  ".doc",
+  ".docx",
+];
 const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+
+function isAcceptedFile(file: File) {
+  if (ACCEPTED_MIME_TYPES.includes(file.type)) return true;
+  const ext = file.name.substring(file.name.lastIndexOf(".")).toLowerCase();
+  return ACCEPTED_EXTENSIONS.includes(ext);
+}
 
 export default function BlueNoticeUpload({
   value,
@@ -39,7 +64,7 @@ export default function BlueNoticeUpload({
       setCurrentFile(file);
       setError("");
 
-      if (!ACCEPTED_TYPES.includes(file.type)) {
+      if (!isAcceptedFile(file)) {
         setStatus("error");
         setError("Unsupported file type");
         return;
@@ -60,9 +85,24 @@ export default function BlueNoticeUpload({
         const fd = new FormData();
         fd.append("file", file);
         const res = await fetch("/api/upload/ocr", { method: "POST", body: fd });
-        const json = await res.json();
-        onOcrComplete(json.text || "", json.meta || {});
-        onChange(json.text || "");
+        const textBody = await res.text();
+        let json: any = {};
+        if (
+          textBody &&
+          res.headers.get("content-type")?.includes("application/json")
+        ) {
+          try {
+            json = JSON.parse(textBody);
+          } catch {}
+        }
+        if (!res.ok) {
+          const msg =
+            json?.meta?.error || json?.error || res.statusText || "OCR failed";
+          throw new Error(msg);
+        }
+        const ocrText = json.text || "";
+        onOcrComplete(ocrText, json.meta || {});
+        if (ocrText) onChange(ocrText);
         setStatus("idle");
       } catch (e: any) {
         console.error(e);
@@ -74,7 +114,7 @@ export default function BlueNoticeUpload({
           bucket: "blue-notices",
           file: { name: file.name, size: file.size, type: file.type },
         });
-        setError(e.message);
+        setError(e?.message || "Upload failed");
         setStatus("error");
       }
     },
@@ -88,6 +128,12 @@ export default function BlueNoticeUpload({
       "application/pdf": [".pdf"],
       "image/png": [".png"],
       "image/jpeg": [".jpg", ".jpeg"],
+      "text/plain": [".txt"],
+      "application/rtf": [".rtf"],
+      "application/msword": [".doc"],
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
+        ".docx",
+      ],
     },
   });
 
@@ -102,7 +148,7 @@ export default function BlueNoticeUpload({
       >
         <input {...getInputProps()} />
         <div className="text-sm text-slate-600">
-          <div className="font-medium mb-1">PDF, PNG or JPG</div>
+          <div className="font-medium mb-1">PDF, PNG, JPG, TXT, RTF, DOC or DOCX</div>
           <div>Drag & drop, or click to choose file</div>
         </div>
       </div>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,6 +14,22 @@ function slugify(name: string): string {
     .replace(/(^-|-$)+/g, "");
 }
 
+function getExtension(name: string): string {
+  const idx = name.lastIndexOf(".");
+  return idx >= 0 ? name.substring(idx).toLowerCase() : "";
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".txt": "text/plain",
+  ".rtf": "application/rtf",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+};
+
 export async function uploadBlueNotice(file: File): Promise<UploadResult> {
   try {
     const uuid = crypto.randomUUID();
@@ -21,12 +37,16 @@ export async function uploadBlueNotice(file: File): Promise<UploadResult> {
     const year = now.getUTCFullYear();
     const month = String(now.getUTCMonth() + 1).padStart(2, "0");
     const day = String(now.getUTCDate()).padStart(2, "0");
-    const slug = slugify(file.name);
+    const ext = getExtension(file.name);
+    const base = file.name.slice(0, file.name.length - ext.length);
+    const slug = `${slugify(base)}${ext}`;
     const objectPath = `${year}/${month}/${day}/${uuid}-${slug}`;
+
+    const contentType = file.type || MIME_BY_EXT[ext] || "application/octet-stream";
 
     const { error } = await supabase.storage
       .from(BUCKET)
-      .upload(objectPath, file, { upsert: false, contentType: file.type });
+      .upload(objectPath, file, { upsert: false, contentType });
 
     if (error) {
       throw error;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,11 +4,11 @@ const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 
 if (!url) {
-  throw new Error("VITE_SUPABASE_URL is not set");
+  throw new Error("Missing VITE_SUPABASE_URL");
 }
 
 if (!key) {
-  throw new Error("VITE_SUPABASE_ANON_KEY is not set");
+  throw new Error("Missing VITE_SUPABASE_ANON_KEY");
 }
 
 export const supabase = createClient(url, key, { auth: { persistSession: false } });

--- a/types/external.d.ts
+++ b/types/external.d.ts
@@ -1,0 +1,2 @@
+declare module 'busboy';
+declare module 'textract';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
+    proxy: {
+      "/api": "http://localhost:5174",
+    },
   },
 })


### PR DESCRIPTION
## Summary
- support DOC, DOCX, TXT, and RTF uploads with better file validation
- add Supabase storage helper with content-type fallback and public URL return
- implement OCR endpoint using pdf-parse, mammoth, textract, and tesseract.js
- proxy `/api` to backend in Vite dev server

## Testing
- `npm run lint` *(fails: ESLint configuration not found)*
- `VITE_SUPABASE_URL='http://example.com' VITE_SUPABASE_ANON_KEY='key' npm test` *(fails: fetch failed for Supabase storage)*

------
https://chatgpt.com/codex/tasks/task_e_68b7226587d8833080db182f635c5c4d