### PR TITLE
feat: support document uploads with OCR pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
 MAIL_FROM="Statutory Advertising <no-reply@example.com>"
+PORT=5174

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -57,7 +57,7 @@ router.post('/', upload, async (req, res) => {
 
     const sanitized = file.originalname.replace(/[^a-z0-9_.-]/gi, '_');
     const uid = uploaderId || 'anon';
-    const filePath = `uploads/${uid}/${Date.now()}_${sanitized}`;
+    const filePath = `${uid}/${Date.now()}_${sanitized}`;
 
     const { error: uploadError } = await sb.storage
       .from('blue-notices')
@@ -100,10 +100,13 @@ router.post('/', upload, async (req, res) => {
 
     sendConfirmation({
       to: applicantEmail,
-      subject: 'Upload received',
-      text: `Your file ${sanitized} has been received`,
-      html: `<p>Your file ${sanitized} has been received.</p><p><a href="${signedUrl}">View file</a></p>`,
-    }).catch((e) => console.error('sendConfirmation', e));
+      applicantName: applicantName || undefined,
+      fileName: sanitized,
+      signedUrl,
+      councilName: councilName || undefined,
+      councilEmail: councilEmail || undefined,
+      premisesAddress: premisesAddress || undefined,
+    });
 
     return res.json({ ok: true, id: row.id, path: filePath, signed_url: signedUrl, ocr_text });
   } catch (err: any) {

--- a/server/utils/mailer.ts
+++ b/server/utils/mailer.ts
@@ -1,27 +1,25 @@
 import nodemailer from 'nodemailer';
 
-export interface MailArgs {
+export interface ConfirmationArgs {
   to: string;
-  subject: string;
-  text: string;
-  html?: string;
+  applicantName?: string;
+  fileName: string;
+  signedUrl?: string;
+  councilName?: string;
+  councilEmail?: string;
+  premisesAddress?: string;
 }
 
-export async function sendConfirmation(args: MailArgs): Promise<void> {
+export async function sendConfirmation(args: ConfirmationArgs): Promise<void> {
   try {
     const resp = await fetch('http://localhost:5174/api/notify', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        to: args.to,
-        subject: args.subject,
-        text: args.text,
-        html: args.html,
-      }),
+      body: JSON.stringify(args),
     });
     if (resp.ok) return;
   } catch (e) {
-    // ignore and fallback
+    // ignore and fallback to SMTP
   }
 
   try {
@@ -34,14 +32,21 @@ export async function sendConfirmation(args: MailArgs): Promise<void> {
         pass: process.env.SMTP_PASS,
       },
     });
+
+    const text = `Your file ${args.fileName} has been received.` +
+      (args.signedUrl ? ` View file: ${args.signedUrl}` : '');
+    const html = `<p>Your file ${args.fileName} has been received.</p>` +
+      (args.signedUrl ? `<p><a href="${args.signedUrl}">View file</a></p>` : '');
+
     await transporter.sendMail({
       from: process.env.MAIL_FROM,
       to: args.to,
-      subject: args.subject,
-      text: args.text,
-      html: args.html,
+      subject: 'Upload received',
+      text,
+      html,
     });
   } catch (e) {
     console.error('sendConfirmation error', e);
   }
 }
+

--- a/server/utils/ocr.ts
+++ b/server/utils/ocr.ts
@@ -1,25 +1,25 @@
 import pdfParse from 'pdf-parse';
+import Tesseract from 'tesseract.js';
 import mammoth from 'mammoth';
 import textract from 'textract';
-import Tesseract from 'tesseract.js';
 
 function mimeFromExt(ext: string): string {
   switch (ext) {
     case '.pdf':
       return 'application/pdf';
-    case '.doc':
-      return 'application/msword';
-    case '.docx':
-      return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-    case '.rtf':
-      return 'application/rtf';
-    case '.txt':
-      return 'text/plain';
     case '.png':
       return 'image/png';
     case '.jpg':
     case '.jpeg':
       return 'image/jpeg';
+    case '.txt':
+      return 'text/plain';
+    case '.rtf':
+      return 'application/rtf';
+    case '.doc':
+      return 'application/msword';
+    case '.docx':
+      return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     default:
       return 'application/octet-stream';
   }
@@ -43,28 +43,68 @@ export async function ocrFile(buffer: Buffer, mime: string, ext: string): Promis
         return '';
       }
     }
-    if (type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' || ext === '.docx') {
-      const data = await mammoth.extractRawText({ buffer });
-      return data.value;
-    }
-    if (type === 'application/msword' || ext === '.doc' || type === 'application/rtf' || ext === '.rtf') {
-      return await new Promise<string>((resolve, reject) => {
-        textract.fromBufferWithMime(type, buffer, (err, text) => {
-          if (err) reject(err);
-          else resolve(text);
-        });
-      });
-    }
-    if (type === 'text/plain' || ext === '.txt') {
-      return buffer.toString('utf-8');
-    }
-    if (type.startsWith('image/') || ['.png', '.jpg', '.jpeg'].includes(ext)) {
+
+    if (
+      type === 'image/png' ||
+      type === 'image/jpeg' ||
+      ['.png', '.jpg', '.jpeg'].includes(ext)
+    ) {
       const result = await Tesseract.recognize(buffer, 'eng');
       return result.data.text;
     }
+
+    if (
+      type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+      ext === '.docx'
+    ) {
+      try {
+        const data = await mammoth.extractRawText({ buffer });
+        if (data.value.trim()) return data.value;
+      } catch (e) {
+        console.error('mammoth failed', e);
+      }
+      return await new Promise<string>((resolve) => {
+        textract.fromBufferWithMime(
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          buffer,
+          (err, text) => {
+            if (err) {
+              console.error('textract docx fallback failed', err);
+              resolve('');
+            } else {
+              resolve(text);
+            }
+          },
+        );
+      });
+    }
+
+    if (
+      type === 'application/msword' ||
+      ext === '.doc' ||
+      type === 'application/rtf' ||
+      ext === '.rtf'
+    ) {
+      return await new Promise<string>((resolve) => {
+        textract.fromBufferWithMime(type, buffer, (err, text) => {
+          if (err) {
+            console.error('textract doc/rtf failed', err);
+            resolve('');
+          } else {
+            resolve(text);
+          }
+        });
+      });
+    }
+
+    if (type === 'text/plain' || ext === '.txt') {
+      return buffer.toString('utf-8');
+    }
+
     return '';
   } catch (err) {
     console.error('ocrFile error', err);
     return '';
   }
 }
+

--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -1,95 +1,105 @@
-import React, { useState, useCallback } from "react";
-import { useDropzone } from "react-dropzone";
-import { uploadBlueNotice } from "../lib/storage";
-
-interface UploadedFile {
-  name: string;
-  size: number;
-  type: string;
-  path: string;
-  publicUrl: string;
-}
+import React, { useCallback, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
 
 interface Props {
   value: string;
   onChange: (v: string) => void;
   onOcrComplete: (text: string, meta: any) => void;
   engine?: string;
-  onUploaded?: (files: UploadedFile[]) => void;
+  applicantEmail?: string;
+  applicantName?: string;
+  councilName?: string;
+  councilEmail?: string;
+  premisesAddress?: string;
+  uploaderId?: string;
 }
 
-const ACCEPTED_TYPES = ["application/pdf", "image/png", "image/jpeg"];
-const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+const ACCEPT = {
+  'application/pdf': ['.pdf'],
+  'image/png': ['.png'],
+  'image/jpeg': ['.jpg', '.jpeg'],
+  'application/msword': ['.doc'],
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
+  'text/plain': ['.txt'],
+  'application/rtf': ['.rtf'],
+};
+
+const UPLOAD_URL = '/api/upload';
 
 export default function BlueNoticeUpload({
   value,
   onChange,
   onOcrComplete,
   engine,
-  onUploaded,
+  applicantEmail,
+  applicantName,
+  councilName,
+  councilEmail,
+  premisesAddress,
+  uploaderId,
 }: Props) {
-  const [status, setStatus] = useState<"idle" | "uploading" | "error">("idle");
-  const [error, setError] = useState("");
-  const [currentFile, setCurrentFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'error'>('idle');
+  const [error, setError] = useState('');
+  const [signedUrl, setSignedUrl] = useState('');
 
   const onDrop = useCallback(
     async (accepted: File[]) => {
       if (!accepted.length) return;
       const file = accepted[0];
-      setCurrentFile(file);
-      setError("");
+      setError('');
+      setStatus('uploading');
 
-      if (!ACCEPTED_TYPES.includes(file.type)) {
-        setStatus("error");
-        setError("Unsupported file. Allowed: PDF, PNG, JPG, TXT, RTF, DOC, DOCX");
-        return;
-      }
-      if (file.size > MAX_SIZE) {
-        setStatus("error");
-        setError("File must be 10 MB or less");
-        return;
-      }
+      const fd = new FormData();
+      fd.append('file', file);
+      if (applicantEmail) fd.append('applicantEmail', applicantEmail);
+      if (applicantName) fd.append('applicantName', applicantName);
+      if (councilName) fd.append('councilName', councilName);
+      if (councilEmail) fd.append('councilEmail', councilEmail);
+      if (premisesAddress) fd.append('premisesAddress', premisesAddress);
+      if (uploaderId) fd.append('uploaderId', uploaderId);
 
-      setStatus("uploading");
       try {
-        // 1) Upload to Supabase Storage
-        const { path, publicUrl } = await uploadBlueNotice(file);
-        onUploaded?.([{ name: file.name, size: file.size, type: file.type, path, publicUrl }]);
+        const res = await fetch(UPLOAD_URL, { method: 'POST', body: fd });
+        const ct = res.headers.get('content-type') || '';
+        let json: any;
+        if (ct.includes('application/json')) {
+          json = await res.json();
+        } else {
+          const text = await res.text();
+          throw new Error(text || 'Unexpected response');
+        }
 
-        // 2) Send to OCR (make JSON parsing robust)
-        const fd = new FormData();
-        fd.append("file", file);
-        const res = await fetch("/api/upload", { method: "POST", body: fd });
-        const json = await res.json();
-        onOcrComplete(json.text || "", json.meta || {});
-        onChange(json.text || "");
-        setStatus("idle");
+        if (!json.ok) {
+          setError(json.error?.message || 'Upload failed');
+          setStatus('error');
+          return;
+        }
+
+        setSignedUrl(json.signed_url || '');
+        onOcrComplete(json.ocr_text || '', json);
+        onChange(json.ocr_text || '');
+        setStatus('idle');
       } catch (e: any) {
-        console.error(e);
-        console.error({
-          env: {
-            hasUrl: !!import.meta.env.VITE_SUPABASE_URL,
-            hasKey: !!import.meta.env.VITE_SUPABASE_ANON_KEY,
-          },
-          bucket: "blue-notices",
-          file: { name: file.name, size: file.size, type: file.type },
-        });
-        setError(e?.message || "Upload failed");
-        setStatus("error");
+        setError(e?.message || 'Upload failed');
+        setStatus('error');
       }
     },
-    [onChange, onOcrComplete, onUploaded]
+    [
+      applicantEmail,
+      applicantName,
+      councilName,
+      councilEmail,
+      premisesAddress,
+      uploaderId,
+      onChange,
+      onOcrComplete,
+    ],
   );
 
-  // Do NOT use `accept` so we can allow doc/docx by extension even if MIME is missing.
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     multiple: false,
-    accept: {
-      "application/pdf": [".pdf"],
-      "image/png": [".png"],
-      "image/jpeg": [".jpg", ".jpeg"],
-    },
+    accept: ACCEPT,
   });
 
   const wordCount = value ? value.trim().split(/\s+/).filter(Boolean).length : 0;
@@ -99,21 +109,30 @@ export default function BlueNoticeUpload({
       <div
         {...getRootProps({
           className: `cursor-pointer rounded-xl border-2 border-dashed p-6 text-center ${
-            isDragActive ? "bg-slate-50" : ""
+            isDragActive ? 'bg-slate-50' : ''
           }`,
         })}
       >
         <input {...getInputProps()} />
         <div className="text-sm text-slate-600">
-          <div className="font-medium mb-1">PDF, PNG or JPG</div>
+          <div className="font-medium mb-1">
+            PDF, PNG, JPG, DOC, DOCX, RTF or TXT
+          </div>
           <div>Drag & drop, or click to choose file</div>
         </div>
       </div>
 
-      {status === "uploading" && currentFile && (
-        <div className="mt-2 text-sm">Uploading {currentFile.name}…</div>
+      {status === 'uploading' && (
+        <div className="mt-2 text-sm">Uploading…</div>
       )}
-      {status === "error" && <div className="mt-2 text-sm text-rose-600">{error}</div>}
+      {status === 'error' && (
+        <div className="mt-2 text-sm text-rose-600">{error}</div>
+      )}
+      {signedUrl && (
+        <div className="mt-2 text-sm">
+          Uploaded file: <a className="underline" href={signedUrl}>{signedUrl}</a>
+        </div>
+      )}
 
       <textarea
         data-testid="notice-editor"
@@ -129,3 +148,4 @@ export default function BlueNoticeUpload({
     </div>
   );
 }
+

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -72,6 +72,11 @@ export default function PublishPage() {
               setEngine(m?.engine || "");
             }}
             engine={engine}
+            applicantName={form.applicantName}
+            applicantEmail={form.applicantEmail}
+            councilName={form.councilName}
+            councilEmail={form.councilEmail}
+            premisesAddress={JSON.stringify(form.premisesAddress)}
           />
           <div className="mt-4">
             <label className="inline-flex items-center gap-2" data-testid="toggle-no-file-builder">


### PR DESCRIPTION
## Summary
- handle pdf/png/jpg/doc/docx/rtf/txt uploads with OCR and Supabase storage
- add fallback OCR utilities and notification mailer
- expand client upload component to accept multiple document types

## Testing
- `npm i express multer @supabase/supabase-js pdf-parse tesseract.js mammoth textract nodemailer cors helmet morgan` *(fails: 403 Forbidden)*
- `npm i -D typescript ts-node tsx @types/express @types/multer @types/node` *(partially succeeds with peer dependency warnings, fails 403)*
- `npm run dev` *(fails: concurrently: not found)*
- `curl -i -X POST http://localhost:5174/api/upload -F "file=@public/logos/westminster.png" -F "applicantEmail=otto@example.com"` *(fails: Couldn't connect to server)*
- `curl -i -X POST http://localhost:5174/api/upload -F "file=@/tmp/sample.docx" -F "applicantEmail=otto@example.com"` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68b82f89b108833082b10e8e789e721a