### PR TITLE
Add council ingestion and searchable API

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "nodemailer": "^6.9.13",
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
-    "zod": "^4.1.5"
+    "zod": "^4.1.5",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/scripts/ingestCouncils.ts
+++ b/scripts/ingestCouncils.ts
@@ -1,46 +1,57 @@
-import fs from 'fs/promises';
 import path from 'path';
-import mammoth from 'mammoth';
+import XLSX from 'xlsx';
 import { createClient } from '@supabase/supabase-js';
 
-interface CouncilRow { name: string; email: string; aliases: string[] }
+interface CouncilRow {
+  name: string;
+  email: string;
+}
 
-async function parseDocx(filePath: string): Promise<CouncilRow[]> {
-  const buffer = await fs.readFile(filePath);
-  const { value } = await mammoth.extractRawText({ buffer });
-  return value
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .map((line: { split: (arg0: RegExp) => [any, any]; }) => {
-      const [name, email] = line.split(/\s+-\s+/);
-      return { name, email, aliases: [] } as CouncilRow;
-    });
+function parseXlsx(filePath: string): CouncilRow[] {
+  const wb = XLSX.readFile(filePath);
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json<Record<string, any>>(ws, { defval: '' });
+
+  return rows
+    .map((r) => {
+      const normalized = Object.fromEntries(
+        Object.entries(r).map(([k, v]) => [k.toLowerCase(), String(v).trim()])
+      );
+      const name =
+        normalized['council name'] ||
+        normalized['name'] ||
+        normalized['council'];
+      const email =
+        normalized['email'] ||
+        normalized['email address'] ||
+        normalized['council email'];
+      return { name, email } as CouncilRow;
+    })
+    .filter((r) => r.name && r.email);
 }
 
 async function main() {
-  const file = path.resolve('data/councils.docx');
-  const councils = await parseDocx(file);
-  await fs.writeFile('councils.json', JSON.stringify(councils, null, 2));
+  const file = path.resolve('Accurate_Council_Emails_From_PDF.xlsx');
+  const councils = parseXlsx(file);
 
   const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    '';
   if (!url || !key) {
     console.error('Missing Supabase credentials');
-    return;
+    process.exit(1);
   }
+
   const client = createClient(url, key);
-  for (const row of councils) {
-    await client.from('councils').upsert({
-      name: row.name,
-      email: row.email,
-      aliases: row.aliases,
-    });
-  }
-  console.log(`Uploaded ${councils.length} councils`);
+  await client.from('councils').upsert(councils, { onConflict: 'name' });
+
+  console.log(`Upserted ${councils.length} councils`);
 }
 
 main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import notifyRouter from './routes/notify';
 import uploadRouter from './routes/upload';
+import councilsRouter from './routes/councils';
 
 const app = express();
 app.use(cors());
@@ -13,6 +14,7 @@ app.use(express.json());
 
 app.use('/api/notify', notifyRouter);
 app.use('/api/upload', uploadRouter);
+app.use('/api/councils', councilsRouter);
 
 // Healthcheck
 app.get('/api/health', (_req, res) => {

--- a/server/routes/councils.ts
+++ b/server/routes/councils.ts
@@ -1,0 +1,39 @@
+import { Router } from 'express';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  const q = String(req.query.q || '').trim();
+  if (!q) return res.json([]);
+
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    return res
+      .status(500)
+      .json({ ok: false, error: { code: 'NO_SUPABASE', message: 'Supabase not configured' } });
+  }
+
+  const sb = createClient(url, key);
+  const { data, error } = await sb
+    .from('councils')
+    .select('id, name, email')
+    .ilike('name', `%${q}%`)
+    .order('name')
+    .limit(10);
+
+  if (error) {
+    return res
+      .status(500)
+      .json({ ok: false, error: { code: 'DB_ERROR', message: error.message } });
+  }
+
+  res.json(data || []);
+});
+
+export default router;
+

--- a/src/components/CouncilCombobox.tsx
+++ b/src/components/CouncilCombobox.tsx
@@ -9,7 +9,7 @@ export interface CouncilOption {
 
 export default function CouncilCombobox({ onSelect }: { onSelect: (c: CouncilOption) => void }) {
   const fetchOptions = async (q: string) => {
-    const res = await fetch(`/api/councils?query=${encodeURIComponent(q)}`);
+    const res = await fetch(`/api/councils?q=${encodeURIComponent(q)}`);
     if (!res.ok) return [];
     return res.json();
   };

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -50,7 +50,7 @@ export default function PublishPage() {
   };
 
   const handleCouncil = (c: CouncilOption) => {
-    setForm((f) => ({ ...f, councilName: c.name, councilEmail: c.email || f.councilEmail }));
+    setForm((f) => ({ ...f, councilName: c.name, councilEmail: c.email || '' }));
   };
 
   const handleAddress = (a: AddressOption) => {

--- a/supabase/migrations/20250811130647_create_councils_table.sql
+++ b/supabase/migrations/20250811130647_create_councils_table.sql
@@ -1,0 +1,7 @@
+create table if not exists councils (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  email text not null,
+  created_at timestamptz default now()
+);
+


### PR DESCRIPTION
## Summary
- load councils from Excel and upsert to Supabase
- expose `/api/councils` search endpoint and integrate in combobox
- auto-fill council email on selection

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fmulter)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8490092f48330b03f289c8c39b9fd