### PR TITLE
Allow anonymous uploads

### DIFF
--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express'
 import Busboy from 'busboy'
 import { randomUUID } from 'node:crypto'
+import { extname } from 'node:path'
 import { createClient } from '@supabase/supabase-js'
 import slugify from 'slugify'
+import { ocrFile } from '../utils/ocr'
 
 const router = Router()
 
@@ -44,17 +46,44 @@ router.post('/', (req, res) => {
     }
     try {
       const now = new Date()
-      const path = `uploads/${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}/${requestId}-${slugify(filename, { lower: true })}`
-      const supa = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+      const safeName = slugify(filename, { lower: true })
+      const path = `uploads/${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}/${requestId}-${safeName}`
+      const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
       const bucket = process.env.SUPABASE_BUCKET || 'notices'
-      const { error } = await supa.storage.from(bucket).upload(path, fileBuffer, { contentType: mimeType })
-      if (error) throw error
-      const { data: pub } = supa.storage.from(bucket).getPublicUrl(path)
+      const uploaded = await supabase.storage.from(bucket).upload(path, fileBuffer, { contentType: mimeType })
+      if (uploaded.error) throw uploaded.error
+      const signed = await supabase.storage.from(bucket).createSignedUrl(path, 60 * 60 * 24 * 365 * 10)
+      if (signed.error) throw signed.error
+      const ocr_text = await ocrFile(fileBuffer, mimeType, extname(filename).toLowerCase())
+      const applicantEmail = fields['applicantEmail']
+      const uploaderId = fields['uploaderId']
+      const row = await supabase
+        .from('uploads')
+        .insert({
+          bucket,
+          path,
+          file_name: safeName,
+          mime_type: mimeType,
+          size_bytes: size,
+          applicant_email: applicantEmail,
+          ocr_text,
+          status: 'processed',
+          public_url: signed.data.signedUrl,
+          uploader_id: uploaderId ?? null, // allow NULL when anonymous
+        })
+        .select()
+        .single()
+      if (row.error) {
+        return res.status(500).json({
+          ok: false,
+          error: { code: 'DB_INSERT_FAIL', message: row.error.message },
+        })
+      }
       console.log(`[upload] ${requestId} ${filename} ${size} -> ${path}`)
-      res.json({ ok: true, path, publicUrl: pub?.publicUrl, mime: mimeType })
+      res.json({ ok: true, ...row.data, publicUrl: row.data?.public_url })
     } catch (err: any) {
       console.error(`[upload ERR] ${requestId}`, err)
-      res.status(500).json({ ok: false, code: 'UPLOAD_FAILED', message: err?.message || 'Upload failed', requestId })
+      res.status(500).json({ ok: false, error: { code: 'UPLOAD_FAILED', message: err?.message || 'Upload failed' }, requestId })
     }
   })
 

--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -1,21 +1,42 @@
 import React, { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+);
 
 async function uploadFile(
   file: File,
-  form: { applicantEmail: string; noticeType?: string }
+  form: {
+    applicantEmail: string;
+    applicantName?: string;
+    councilName?: string;
+    councilEmail?: string;
+    premisesAddress?: string;
+  }
 ) {
   const fd = new FormData();
-  fd.append('file', file);
+  fd.append('file', file); // must be 'file'
   fd.append('applicantEmail', form.applicantEmail);
-  if (form.noticeType) fd.append('noticeType', form.noticeType);
+  if (form.applicantName) fd.append('applicantName', form.applicantName);
+  if (form.councilName) fd.append('councilName', form.councilName);
+  if (form.councilEmail) fd.append('councilEmail', form.councilEmail);
+  if (form.premisesAddress) fd.append('premisesAddress', form.premisesAddress);
+
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (user?.id) fd.append('uploaderId', user.id);
+
   const res = await fetch('/api/upload', { method: 'POST', body: fd });
   const ct = res.headers.get('content-type') || '';
   const out = ct.includes('application/json')
     ? await res.json()
-    : { ok: false, message: await res.text() };
+    : { ok: false, error: { message: await res.text() } };
   if (!res.ok || !out.ok) {
-    throw new Error(out?.message || `Upload failed (${res.status})`);
+    throw new Error(out?.error?.message || `Upload failed (${res.status})`);
   }
   return out;
 }
@@ -26,7 +47,10 @@ interface Props {
   onOcrComplete: (text: string, meta: any) => void;
   engine?: string;
   applicantEmail?: string;
-  noticeType?: string;
+  applicantName?: string;
+  councilName?: string;
+  councilEmail?: string;
+  premisesAddress?: string;
 }
 
 const ACCEPT = {
@@ -45,7 +69,10 @@ export default function BlueNoticeUpload({
   onOcrComplete,
   engine,
   applicantEmail,
-  noticeType,
+  applicantName,
+  councilName,
+  councilEmail,
+  premisesAddress,
 }: Props) {
   const [status, setStatus] = useState<'idle' | 'uploading' | 'error'>('idle');
   const [error, setError] = useState('');
@@ -60,7 +87,10 @@ export default function BlueNoticeUpload({
       try {
         const json = await uploadFile(file, {
           applicantEmail,
-          noticeType,
+          applicantName,
+          councilName,
+          councilEmail,
+          premisesAddress,
         });
         setSignedUrl(json.publicUrl || '');
         onOcrComplete(json.ocr_text || '', json);
@@ -71,7 +101,15 @@ export default function BlueNoticeUpload({
         setStatus('error');
       }
     },
-    [applicantEmail, noticeType, onChange, onOcrComplete]
+    [
+      applicantEmail,
+      applicantName,
+      councilName,
+      councilEmail,
+      premisesAddress,
+      onChange,
+      onOcrComplete,
+    ]
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({


### PR DESCRIPTION
## Summary
- Allow optional uploader ID for uploads and insert file metadata to DB
- Send uploaderId from client only when logged in via Supabase auth

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b85b528cd0833080bf484195536f8a