### PR TITLE
Allow anonymous uploads

### DIFF
--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -1,64 +1,97 @@
 import { Router } from 'express'
-import Busboy from 'busboy'
+import multer from 'multer'
 import { randomUUID } from 'node:crypto'
+import { extname } from 'node:path'
 import { createClient } from '@supabase/supabase-js'
 import slugify from 'slugify'
+import { ocrFile } from '../utils/ocr'
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+})
 
 const router = Router()
 
-router.post('/', (req, res) => {
-  const bb = Busboy({ headers: req.headers, limits: { fileSize: 10 * 1024 * 1024 } })
-  let fileBuffer: Buffer | null = null
-  let filename = ''
-  let mimeType = ''
-  let size = 0
-  let fileHandled = false
-  const fields: Record<string, string> = {}
+router.post('/', upload.single('file'), async (req, res) => {
   const requestId = randomUUID()
-
-  bb.on('field', (name, val) => {
-    fields[name] = val
-  })
-
-  bb.on('file', (_name, file, info) => {
-    fileHandled = true
-    filename = info.filename
-    mimeType = info.mimeType
-    const chunks: Buffer[] = []
-    file.on('data', (d) => {
-      chunks.push(d)
-      size += d.length
+  const file = req.file
+  if (!file) {
+    return res.status(400).json({
+      ok: false,
+      code: 'NO_FILE',
+      message: 'No file provided',
+      requestId,
     })
-    file.on('limit', () => {
-      res.status(413).json({ ok: false, code: 'FILE_TOO_LARGE', message: 'File too large', requestId })
-    })
-    file.on('end', () => {
-      fileBuffer = Buffer.concat(chunks)
-    })
-  })
+  }
 
-  bb.on('close', async () => {
-    if (res.headersSent) return
-    if (!fileHandled || !fileBuffer) {
-      return res.status(400).json({ ok: false, code: 'NO_FILE', message: 'No file provided', requestId })
+  try {
+    const now = new Date()
+    const safeName = slugify(file.originalname, { lower: true })
+    const path = `uploads/${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(
+      now.getDate(),
+    ).padStart(2, '0')}/${requestId}-${safeName}`
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    )
+    const bucket = process.env.SUPABASE_BUCKET || 'notices'
+
+    const uploaded = await supabase.storage
+      .from(bucket)
+      .upload(path, file.buffer, { contentType: file.mimetype })
+    if (uploaded.error) throw uploaded.error
+
+    const signed = await supabase.storage
+      .from(bucket)
+      .createSignedUrl(path, 60 * 60 * 24 * 365 * 10)
+    if (signed.error) throw signed.error
+
+    const ocr_text = await ocrFile(
+      file.buffer,
+      file.mimetype,
+      extname(file.originalname).toLowerCase(),
+    )
+
+    const applicantEmail = req.body['applicantEmail']
+    const uploaderId = req.body['uploaderId']
+
+    const row = await supabase
+      .from('uploads')
+      .insert({
+        bucket,
+        path,
+        file_name: safeName,
+        mime_type: file.mimetype,
+        size_bytes: file.size,
+        applicant_email: applicantEmail,
+        ocr_text,
+        status: 'processed',
+        public_url: signed.data.signedUrl,
+        uploader_id: uploaderId ?? null, // allow NULL when anonymous
+      })
+      .select()
+      .single()
+
+    if (row.error) {
+      return res.status(500).json({
+        ok: false,
+        error: { code: 'DB_INSERT_FAIL', message: row.error.message },
+      })
     }
-    try {
-      const now = new Date()
-      const path = `uploads/${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}/${requestId}-${slugify(filename, { lower: true })}`
-      const supa = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
-      const bucket = process.env.SUPABASE_BUCKET || 'notices'
-      const { error } = await supa.storage.from(bucket).upload(path, fileBuffer, { contentType: mimeType })
-      if (error) throw error
-      const { data: pub } = supa.storage.from(bucket).getPublicUrl(path)
-      console.log(`[upload] ${requestId} ${filename} ${size} -> ${path}`)
-      res.json({ ok: true, path, publicUrl: pub?.publicUrl, mime: mimeType })
-    } catch (err: any) {
-      console.error(`[upload ERR] ${requestId}`, err)
-      res.status(500).json({ ok: false, code: 'UPLOAD_FAILED', message: err?.message || 'Upload failed', requestId })
-    }
-  })
 
-  req.pipe(bb)
+    console.log(`[upload] ${requestId} ${file.originalname} ${file.size} -> ${path}`)
+    res.json({ ok: true, ...row.data, publicUrl: row.data?.public_url })
+  } catch (err: any) {
+    console.error(`[upload ERR] ${requestId}`, err)
+    res.status(500).json({
+      ok: false,
+      error: { code: 'UPLOAD_FAILED', message: err?.message || 'Upload failed' },
+      requestId,
+    })
+  }
 })
 
 export default router
+

--- a/src/components/BlueNoticeUpload.tsx
+++ b/src/components/BlueNoticeUpload.tsx
@@ -1,21 +1,42 @@
 import React, { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+);
 
 async function uploadFile(
   file: File,
-  form: { applicantEmail: string; noticeType?: string }
+  form: {
+    applicantEmail: string;
+    applicantName?: string;
+    councilName?: string;
+    councilEmail?: string;
+    premisesAddress?: string;
+  }
 ) {
   const fd = new FormData();
-  fd.append('file', file);
+  fd.append('file', file); // must be 'file'
   fd.append('applicantEmail', form.applicantEmail);
-  if (form.noticeType) fd.append('noticeType', form.noticeType);
+  if (form.applicantName) fd.append('applicantName', form.applicantName);
+  if (form.councilName) fd.append('councilName', form.councilName);
+  if (form.councilEmail) fd.append('councilEmail', form.councilEmail);
+  if (form.premisesAddress) fd.append('premisesAddress', form.premisesAddress);
+
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (user?.id) fd.append('uploaderId', user.id);
+
   const res = await fetch('/api/upload', { method: 'POST', body: fd });
   const ct = res.headers.get('content-type') || '';
   const out = ct.includes('application/json')
     ? await res.json()
-    : { ok: false, message: await res.text() };
+    : { ok: false, error: { message: await res.text() } };
   if (!res.ok || !out.ok) {
-    throw new Error(out?.message || `Upload failed (${res.status})`);
+    throw new Error(out?.error?.message || `Upload failed (${res.status})`);
   }
   return out;
 }
@@ -26,7 +47,10 @@ interface Props {
   onOcrComplete: (text: string, meta: any) => void;
   engine?: string;
   applicantEmail?: string;
-  noticeType?: string;
+  applicantName?: string;
+  councilName?: string;
+  councilEmail?: string;
+  premisesAddress?: string;
 }
 
 const ACCEPT = {
@@ -45,7 +69,10 @@ export default function BlueNoticeUpload({
   onOcrComplete,
   engine,
   applicantEmail,
-  noticeType,
+  applicantName,
+  councilName,
+  councilEmail,
+  premisesAddress,
 }: Props) {
   const [status, setStatus] = useState<'idle' | 'uploading' | 'error'>('idle');
   const [error, setError] = useState('');
@@ -60,7 +87,10 @@ export default function BlueNoticeUpload({
       try {
         const json = await uploadFile(file, {
           applicantEmail,
-          noticeType,
+          applicantName,
+          councilName,
+          councilEmail,
+          premisesAddress,
         });
         setSignedUrl(json.publicUrl || '');
         onOcrComplete(json.ocr_text || '', json);
@@ -71,7 +101,15 @@ export default function BlueNoticeUpload({
         setStatus('error');
       }
     },
-    [applicantEmail, noticeType, onChange, onOcrComplete]
+    [
+      applicantEmail,
+      applicantName,
+      councilName,
+      councilEmail,
+      premisesAddress,
+      onChange,
+      onOcrComplete,
+    ]
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({


### PR DESCRIPTION
## Summary
- Switch upload API to multer memory storage and keep OCR flow
- Allow optional uploader ID when inserting upload metadata
- Send uploaderId from client only when logged in via Supabase auth

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b85b528cd0833080bf484195536f8a