### PR TITLE
feat: add upload preview and progress shimmer

### DIFF
--- a/src/__tests__/uploadDropzone.test.tsx
+++ b/src/__tests__/uploadDropzone.test.tsx
@@ -3,12 +3,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import PublishPage from '@/pages/PublishPage';
 
 describe('UploadDropzone status transitions', () => {
-  it('goes to ready in test mode and sets notice-editor text', async () => {
+  it('goes to done in test mode and sets notice-editor text', async () => {
     render(<PublishPage />);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['abc'], 'test.pdf', { type: 'application/pdf' });
     fireEvent.change(input, { target: { files: [file] } });
-    await waitFor(() => expect(screen.getAllByText(/Status: ready/i)[0]).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText(/Status: done/i)[0]).toBeInTheDocument());
     const editor = screen.getByTestId('notice-editor') as HTMLTextAreaElement;
     expect(editor.value).toBe('hello');
   });

--- a/src/components/NoticePreview.tsx
+++ b/src/components/NoticePreview.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export default function NoticePreview({ text }: { text: string }) {
+  const copy = async () => {
+    try {
+      await navigator.clipboard?.writeText(text);
+    } catch {
+      /* ignore */
+    }
+  };
+  const download = () => {
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'notice.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <section className="mt-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words font-mono text-sm text-slate-800">
+        {text}
+      </pre>
+      <div className="mt-3 flex gap-2">
+        <button
+          aria-label="Copy text"
+          className="rounded-md border px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          onClick={copy}
+        >
+          Copy text
+        </button>
+        <button
+          aria-label="Download .txt"
+          className="rounded-md border px-2 py-1 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          onClick={download}
+        >
+          Download .txt
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/__tests__/NoticePreview.test.tsx
+++ b/src/components/__tests__/NoticePreview.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import NoticePreview from '../NoticePreview';
+
+describe('NoticePreview', () => {
+  it('shows copy and download buttons', () => {
+    render(<NoticePreview text="hello" />);
+    expect(screen.getByRole('button', { name: /copy text/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download .txt/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/publish/UploadDropzone.tsx
+++ b/src/components/publish/UploadDropzone.tsx
@@ -8,7 +8,7 @@ export type UploadDropzoneProps = {
 };
 
 export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) {
-  const [state, setState] = useState<'idle'|'uploading'|'ocr'|'ready'|'error'>('idle');
+  const [state, setState] = useState<'idle'|'uploading'|'ocr'|'done'|'failed'>('idle');
   const [elapsed, setElapsed] = useState(0);
   const [error, setError] = useState('');
   const [localText, setLocalText] = useState('');
@@ -37,7 +37,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
         setLocalText('hello');
         onText('hello');
         onMeta?.({ engine: 'test' });
-        setState('ready');
+        setState('done');
         setElapsed(performance.now() - t0);
         return;
       }
@@ -55,10 +55,10 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
       if (data?.error === 'OCR_EMPTY') {
         setError("We couldn't read this file. Build from details instead.");
       }
-      setState('ready');
+      setState('done');
       setElapsed(performance.now() - t0);
     } catch (e) {
-      setState('error');
+      setState('failed');
       setElapsed(performance.now() - t0);
       setError('Upload failed. You can still edit everything manually.');
     }
@@ -81,9 +81,9 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
     onDropRejected: () => setError('Unsupported file or file over 25MB.'),
   });
 
-  const statusLabel = state === 'ready'
-    ? 'Ready'
-    : state === 'error'
+  const statusLabel = state === 'done'
+    ? 'Done'
+    : state === 'failed'
     ? 'Failed'
     : state === 'ocr'
     ? 'OCR running…'
@@ -102,12 +102,14 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
     setLastFile(null);
     setState('idle');
     setError('');
+    setLocalText('');
+    onText('');
     const input = rootRef.current?.querySelector('input[type="file"]') as HTMLInputElement | null;
     if (input) input.value = '';
   };
 
   useEffect(() => {
-    if (state === 'ready') {
+    if (state === 'done') {
       document.getElementById('notice-preview')?.scrollIntoView({ behavior: 'smooth' });
     }
   }, [state]);
@@ -132,7 +134,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
         />
         <p className="text-sm text-slate-600">Drop PDF/DOCX/PNG/JPG (≤25MB) or click to upload</p>
         <p className="mt-2 text-xs text-slate-500">OCR will appear below; you can still edit everything.</p>
-        <div className="sr-only" aria-live="polite">Status: {state}</div>
+        <div className="sr-only" aria-live="polite">Status: {statusLabel}</div>
       </div>
 
       <AnimatePresence>
@@ -146,7 +148,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
           >
             <span className="truncate">{(acceptedFiles[0] || lastFile)!.name} · {pretty((acceptedFiles[0] || lastFile)!.size)} · {statusLabel}</span>
             <div className="flex gap-2">
-              {state === 'error' && (
+              {state === 'failed' && (
                 <button
                   className="rounded-md border px-2 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
                   onClick={retry}
@@ -167,12 +169,12 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
 
       {(state === 'uploading' || state === 'ocr') && (
         <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-slate-200">
-          <div className="h-full w-full bg-gradient-to-r from-blue-400 via-blue-200 to-blue-400 bg-[length:200%_100%] animate-progress" />
+          <div className="h-full w-full bg-gradient-to-r from-blue-400 via-blue-200 to-blue-400 bg-[length:200%_100%] animate-shimmer" />
         </div>
       )}
 
-      <div className="mt-3 text-xs text-slate-600">Status: {state} {elapsed ? `(${Math.round(elapsed)} ms)` : ''}</div>
-      {state === 'ready' && (
+      <div className="mt-3 text-xs text-slate-600">Status: {statusLabel} {elapsed ? `(${Math.round(elapsed)} ms)` : ''}</div>
+      {state === 'done' && (
         <div className="mt-3 space-y-2" aria-live="polite">
           <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800" role="status">
             Extracted {localText.length} characters from file

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -5,13 +5,15 @@ import ApplicantPanel from '@/components/publish/ApplicantPanel';
 import ApplicationBasics, { type ApplicationBasicsValue } from '@/components/publish/ApplicationBasics';
 import ActivitiesHours, { type ActivityRow } from '@/components/publish/ActivitiesHours';
 import Checklist from '@/components/publish/ComplianceChecklist';
-import NoticePreview from '@/components/publish/NoticePreview';
+import NoticePreview from '@/components/NoticePreview';
+import PublishNoticePreview from '@/components/publish/NoticePreview';
 import UploadDropzone from '@/components/publish/UploadDropzone';
 import { type PremisesData } from '@/schemas/premises';
 import { renderPremisesNotice } from '@/lib/renderNotice';
 
 export default function PublishPage() {
   const [noticeText, setNoticeText] = useState("");
+  const [previewText, setPreviewText] = useState("");
   const [meta, setMeta] = useState<any>({});
   const [publishing, setPublishing] = useState(false);
 
@@ -163,12 +165,19 @@ export default function PublishPage() {
           </select>
         </div>
 
-        <UploadDropzone onText={(t) => setNoticeText(t)} onMeta={(m) => setMeta(m)} />
+        <UploadDropzone
+          onText={(t) => {
+            setNoticeText(t);
+            setPreviewText(t);
+          }}
+          onMeta={(m) => setMeta(m)}
+        />
+        {previewText && <NoticePreview text={previewText} />}
 
         <ApplicationBasics value={basics} onChange={setBasics} />
         <ActivitiesHours rows={activities} onChange={setActivities} />
         <Checklist issues={issues} onFix={onFix} />
-        <NoticePreview text={renderPremisesNotice({
+        <PublishNoticePreview text={renderPremisesNotice({
           ...assembled,
           councilName: form.councilName || 'Council',
           officeAddress: councilMeta.officeAddress,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,9 +9,14 @@ export default {
           '0%': { backgroundPosition: '0% 0%' },
           '100%': { backgroundPosition: '200% 0%' },
         },
+        shimmer: {
+          '0%': { backgroundPosition: '-200% 0%' },
+          '100%': { backgroundPosition: '200% 0%' },
+        },
       },
       animation: {
         progress: 'progress 1.5s linear infinite',
+        shimmer: 'shimmer 1.5s linear infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add OCR text preview card with copy and download actions
- enhance upload dropzone with shimmer progress and clearer status
- wire preview into publish page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open './test/data/05-versions-space.pdf')*
- `npm run lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a979b8e48330abe11b478059e247