### PR TITLE
feat(publish): modern upload, live preview, actionable checklist

### DIFF
--- a/src/components/__tests__/NoticePreview.test.tsx
+++ b/src/components/__tests__/NoticePreview.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import NoticePreview from '../NoticePreview';
+import NoticePreview from '../publish/NoticePreview';
 
 describe('NoticePreview', () => {
-  it('shows copy and download buttons', () => {
+  it('renders text with copy and download actions', () => {
     render(<NoticePreview text="hello" />);
-    expect(screen.getByRole('button', { name: /copy text/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /download .txt/i })).toBeInTheDocument();
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument();
   });
 });

--- a/src/components/publish/ComplianceChecklist.tsx
+++ b/src/components/publish/ComplianceChecklist.tsx
@@ -1,37 +1,81 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 
-export type ChecklistProps = { issues: string[]; onFix: () => void };
+export type ChecklistItem = {
+  id: string;
+  label: string;
+  ok: boolean;
+  target: string;
+};
 
-export default function Checklist({ issues, onFix }: ChecklistProps) {
-  const hasIssues = (issues?.length || 0) > 0;
+export default function ComplianceChecklist({ items }: { items: ChecklistItem[] }) {
+  const prev = useRef<Record<string, boolean>>({});
+  const [announcement, setAnnouncement] = useState('');
+
+  useEffect(() => {
+    const turnedGreen = items.filter((i) => i.ok && prev.current[i.id] === false);
+    if (turnedGreen.length > 0) {
+      setAnnouncement(`${turnedGreen[0].label} resolved`);
+    }
+    items.forEach((i) => {
+      prev.current[i.id] = i.ok;
+    });
+  }, [items]);
+
+  const fix = (target: string) => {
+    const el = document.getElementById(target) as HTMLElement | null;
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    (el?.querySelector('input,select,textarea,button,[tabindex]') as HTMLElement | null)?.focus?.();
+  };
+
+  const allGood = items.every((i) => i.ok);
+
   return (
-    <div className="rounded-xl border bg-white p-5 shadow-sm" role="region" aria-label="Publication-ready checklist">
-      <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold tracking-tight">Publication-ready checklist</h3>
-        {hasIssues && (
-          <button
-            type="button"
-            className="rounded-md border px-3 py-1.5 text-sm"
-            onClick={onFix}
-          >
-            Fix first issue
-          </button>
-        )}
-      </div>
-      <ul className="space-y-1 text-sm">
-        {!hasIssues && (
-          <li className="flex items-center gap-2 text-emerald-700">
-            <span aria-hidden className="inline-block w-2.5 h-2.5 rounded-full bg-emerald-600" />
-            All checks passed — ready to publish
-          </li>
-        )}
-        {issues?.map((msg, i) => (
-          <li key={i} className="flex items-start gap-2">
-            <span aria-hidden className="mt-1 inline-block w-2.5 h-2.5 rounded-full bg-amber-600" />
-            <span className="text-slate-800">{msg}</span>
-          </li>
-        ))}
+    <div className="rounded-xl border bg-white p-5 shadow-sm" role="region" aria-label="Compliance checklist">
+      <h3 className="mb-3 text-sm font-semibold tracking-tight">Compliance checklist</h3>
+      <ul className="space-y-2 text-sm">
+        <AnimatePresence initial={false}>
+          {allGood && (
+            <motion.li
+              layout
+              key="all-good"
+              className="flex items-center gap-2 text-emerald-700"
+            >
+              <span aria-hidden className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-emerald-600 text-white text-[10px]">✔</span>
+              All checks passed — ready to publish
+            </motion.li>
+          )}
+          {!allGood &&
+            items.map((item) => (
+              <motion.li
+                layout
+                key={item.id}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    aria-hidden
+                    className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${item.ok ? 'bg-emerald-600 text-white' : 'bg-red-600 text-white'}`}
+                  >
+                    {item.ok ? '✔' : '✘'}
+                  </span>
+                  <span className="text-slate-800">{item.label}</span>
+                </div>
+                {!item.ok && (
+                  <button
+                    className="ml-4 rounded-md border px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+                    onClick={() => fix(item.target)}
+                  >
+                    Fix this
+                  </button>
+                )}
+              </motion.li>
+            ))}
+        </AnimatePresence>
       </ul>
+      <div className="sr-only" aria-live="polite">
+        {announcement}
+      </div>
     </div>
   );
 }

--- a/src/components/publish/NoticePreview.tsx
+++ b/src/components/publish/NoticePreview.tsx
@@ -25,23 +25,29 @@ export default function NoticePreview({ text }: { text: string }) {
   return (
     <section
       id="notice-preview"
-      className="mt-6 rounded-2xl border bg-white p-6 md:p-8 shadow-sm transition-all"
+      className="rounded-2xl border bg-white p-6 md:p-8 shadow-sm"
     >
-      <h3 className="mb-3 text-sm font-semibold tracking-tight">Preview (read-only)</h3>
-      <article className="mx-auto max-w-[720px] font-serif text-[15px] leading-7 tracking-[0.003em] text-justify hyphens-auto">
-        <pre className="whitespace-pre-wrap break-words">{text}</pre>
-      </article>
+      <h3 className="mb-3 text-sm font-semibold tracking-tight">Notice preview</h3>
+      {text ? (
+        <pre className="max-h-[70vh] overflow-y-auto whitespace-pre-wrap break-words font-mono text-sm leading-relaxed">
+          {text}
+        </pre>
+      ) : (
+        <p className="text-sm text-slate-500">
+          Your notice preview will appear here after upload or as you type.
+        </p>
+      )}
       <div className="mt-6 flex justify-end gap-2">
         <button
           aria-label="Copy notice text"
-          className="rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          className="rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           onClick={copyText}
         >
           Copy
         </button>
         <button
           aria-label="Download notice text"
-          className="rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          className="rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           onClick={downloadTxt}
         >
           Download .txt

--- a/src/components/publish/UploadDropzone.tsx
+++ b/src/components/publish/UploadDropzone.tsx
@@ -8,7 +8,7 @@ export type UploadDropzoneProps = {
 };
 
 export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) {
-  const [state, setState] = useState<'idle'|'uploading'|'ocr'|'done'|'failed'>('idle');
+  const [state, setState] = useState<'idle'|'uploading'|'ocrRunning'|'success'|'failed'>('idle');
   const [elapsed, setElapsed] = useState(0);
   const [error, setError] = useState('');
   const [localText, setLocalText] = useState('');
@@ -32,12 +32,12 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
       const isTest = (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')
         || (typeof import.meta !== 'undefined' && (import.meta as any)?.env?.MODE === 'test');
       if (isTest) {
-        setState('ocr');
+        setState('ocrRunning');
         await new Promise((r) => setTimeout(r, 10));
         setLocalText('hello');
         onText('hello');
         onMeta?.({ engine: 'test' });
-        setState('done');
+        setState('success');
         setElapsed(performance.now() - t0);
         return;
       }
@@ -45,7 +45,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
       const fd = new FormData();
       fd.append('file', file);
       const res = await fetch('/api/upload', { method: 'POST', body: fd });
-      setState('ocr');
+      setState('ocrRunning');
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json(); // { text, meta, error? }
       const text = data?.text || '';
@@ -55,7 +55,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
       if (data?.error === 'OCR_EMPTY') {
         setError("We couldn't read this file. Build from details instead.");
       }
-      setState('done');
+      setState('success');
       setElapsed(performance.now() - t0);
     } catch (e) {
       setState('failed');
@@ -81,12 +81,12 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
     onDropRejected: () => setError('Unsupported file or file over 25MB.'),
   });
 
-  const statusLabel = state === 'done'
+  const statusLabel = state === 'success'
     ? 'Done'
     : state === 'failed'
     ? 'Failed'
-    : state === 'ocr'
-    ? 'OCR running…'
+    : state === 'ocrRunning'
+    ? 'Running OCR…'
     : state === 'uploading'
     ? 'Uploading…'
     : 'Idle';
@@ -109,7 +109,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
   };
 
   useEffect(() => {
-    if (state === 'done') {
+    if (state === 'success') {
       document.getElementById('notice-preview')?.scrollIntoView({ behavior: 'smooth' });
     }
   }, [state]);
@@ -167,14 +167,14 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
         )}
       </AnimatePresence>
 
-      {(state === 'uploading' || state === 'ocr') && (
+      {(state === 'uploading' || state === 'ocrRunning') && (
         <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-slate-200">
           <div className="h-full w-full bg-gradient-to-r from-blue-400 via-blue-200 to-blue-400 bg-[length:200%_100%] animate-shimmer" />
         </div>
       )}
 
       <div className="mt-3 text-xs text-slate-600">Status: {statusLabel} {elapsed ? `(${Math.round(elapsed)} ms)` : ''}</div>
-      {state === 'done' && (
+      {state === 'success' && (
         <div className="mt-3 space-y-2" aria-live="polite">
           <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800" role="status">
             Extracted {localText.length} characters from file
@@ -189,8 +189,24 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
         </div>
       )}
       {error && (
-        <div className="mt-2 rounded border border-amber-200 bg-amber-50 p-2 text-sm text-amber-700" role="status" aria-live="polite">
-          {error}
+        <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800" role="status" aria-live="polite">
+          <div className="flex items-center justify-between gap-4">
+            <span>{error}</span>
+            <div className="flex gap-2 shrink-0">
+              <button
+                className="rounded-md border px-2 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+                onClick={retry}
+              >
+                Retry
+              </button>
+              <button
+                className="rounded-md border px-2 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+                onClick={remove}
+              >
+                Paste text manually
+              </button>
+            </div>
+          </div>
         </div>
       )}
       {/* Hidden but present editor for tests and manual adjustments elsewhere can bind into it */}

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -4,12 +4,10 @@ import AppShell from '@/components/publish/AppShell';
 import ApplicantPanel from '@/components/publish/ApplicantPanel';
 import ApplicationBasics, { type ApplicationBasicsValue } from '@/components/publish/ApplicationBasics';
 import ActivitiesHours, { type ActivityRow } from '@/components/publish/ActivitiesHours';
-import Checklist from '@/components/publish/ComplianceChecklist';
-import NoticePreview from '@/components/NoticePreview';
-import PublishNoticePreview from '@/components/publish/NoticePreview';
+import ComplianceChecklist, { type ChecklistItem } from '@/components/publish/ComplianceChecklist';
+import NoticePreview from '@/components/publish/NoticePreview';
 import UploadDropzone from '@/components/publish/UploadDropzone';
 import { type PremisesData } from '@/schemas/premises';
-import { renderPremisesNotice } from '@/lib/renderNotice';
 
 export default function PublishPage() {
   const [noticeText, setNoticeText] = useState("");
@@ -24,8 +22,8 @@ export default function PublishPage() {
     councilEmail: "",
     premisesAddress: { line1: "", line2: "", line3: "", city: "", postcode: "" },
   });
-  const steps = ['Type', 'Upload or Build', 'Applicant', 'Details', 'Preview & Publish'] as const;
-  const [currentStep, setCurrentStep] = useState<number>(1);
+  const steps = ['Upload & OCR', 'Applicant', 'Details', 'Review'] as const;
+  const [currentStep, setCurrentStep] = useState<number>(0);
   const [noticeType, setNoticeType] = useState<'premises' | 'traffic' | 'gambling' | 'planning' | 'gvol' | 'probate'>('premises');
   const [basics, setBasics] = useState<ApplicationBasicsValue>({
     applicationType: 'grant',
@@ -54,17 +52,15 @@ export default function PublishPage() {
     variationSummary: basics.variationSummary,
     activities: activities as any,
   };
-  const issues = useMemo(() => {
-    const errs: string[] = [];
-    if (!assembled.applicantName?.trim()) errs.push('Applicant name is required');
-    if (!(assembled.councilId && assembled.councilEmail)) errs.push('Council and reps contact required');
-    if (!(assembled.premisesTradingName && assembled.address?.line1 && assembled.address?.postcode && assembled.address?.city)) errs.push('Trading name and full address required');
-    if (!assembled.applicationType) errs.push('Application type required');
-    if (!assembled.representationDeadline) errs.push('Representation deadline required');
-    if (!((assembled.activities || []).length > 0)) errs.push('List at least one licensable activity');
-    return errs;
-  }, [assembled]);
-  const disabled = publishing || issues.length > 0;
+  const checklist: ChecklistItem[] = useMemo(() => [
+    { id: 'applicant', label: 'Applicant name required', ok: !!assembled.applicantName?.trim(), target: 'applicant-section' },
+    { id: 'council', label: 'Council and reps contact required', ok: !!(assembled.councilId && assembled.councilEmail), target: 'applicant-section' },
+    { id: 'address', label: 'Trading name and full address required', ok: !!(assembled.premisesTradingName && assembled.address?.line1 && assembled.address?.postcode && assembled.address?.city), target: 'basics-section' },
+    { id: 'type', label: 'Application type required', ok: !!assembled.applicationType, target: 'basics-section' },
+    { id: 'deadline', label: 'Representation deadline required', ok: !!assembled.representationDeadline, target: 'basics-section' },
+    { id: 'activities', label: 'List at least one licensable activity', ok: (assembled.activities || []).length > 0, target: 'activities-section' },
+  ], [assembled]);
+  const disabled = publishing || checklist.some((i) => !i.ok);
 
   const handlePublish = async () => {
     if (disabled) return;
@@ -102,36 +98,17 @@ export default function PublishPage() {
     setForm((f) => ({ ...f, premisesAddress: { line1, line2, line3, city, postcode } }));
   };
 
-  const onFix = () => {
-    const el = document.querySelector('[data-error="true"]') as HTMLElement | null;
-    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    (el?.querySelector('input,select,textarea,button,[tabindex]') as HTMLElement | null)?.focus?.();
-  };
 
   return (
     <AppShell
       title="Publish a Notice"
       steps={steps}
       currentStep={currentStep}
-      onStepChange={setCurrentStep}
+      onStepChange={(i) => i <= currentStep && setCurrentStep(i)}
       rail={(
         <div className="sticky top-6 space-y-4">
-          <ApplicantPanel
-            applicantName={form.applicantName}
-            applicantEmail={form.applicantEmail}
-            councilName={form.councilName}
-            councilEmail={form.councilEmail}
-            address={form.premisesAddress}
-            onPatch={(patch) => setForm((f) => ({ ...f, ...(patch as any) }))}
-            onSelectAddress={handleAddress}
-            onCouncilMeta={(meta) => setCouncilMeta({
-              officeAddress: (meta as any).officeAddress,
-              licensingUrl: (meta as any).licensingUrl,
-              postalAddress: (meta as any).postalAddress || (meta as any).postal,
-              repsEmail: (meta as any).repsEmail,
-              repsUrl: (meta as any).repsUrl,
-            })}
-          />
+          <NoticePreview text={previewText} />
+          <ComplianceChecklist items={checklist} />
         </div>
       )}
       footer={(
@@ -172,21 +149,33 @@ export default function PublishPage() {
           }}
           onMeta={(m) => setMeta(m)}
         />
-        {previewText && <NoticePreview text={previewText} />}
 
-        <ApplicationBasics value={basics} onChange={setBasics} />
-        <ActivitiesHours rows={activities} onChange={setActivities} />
-        <Checklist issues={issues} onFix={onFix} />
-        <PublishNoticePreview text={renderPremisesNotice({
-          ...assembled,
-          councilName: form.councilName || 'Council',
-          officeAddress: councilMeta.officeAddress,
-          licensingUrl: councilMeta.licensingUrl,
-          postalAddress: councilMeta.postalAddress,
-          repsEmail: councilMeta.repsEmail,
-          repsUrl: councilMeta.repsUrl,
-          region: basics.region,
-        })} />
+        <div id="applicant-section">
+          <ApplicantPanel
+            applicantName={form.applicantName}
+            applicantEmail={form.applicantEmail}
+            councilName={form.councilName}
+            councilEmail={form.councilEmail}
+            address={form.premisesAddress}
+            onPatch={(patch) => setForm((f) => ({ ...f, ...(patch as any) }))}
+            onSelectAddress={handleAddress}
+            onCouncilMeta={(meta) => setCouncilMeta({
+              officeAddress: (meta as any).officeAddress,
+              licensingUrl: (meta as any).licensingUrl,
+              postalAddress: (meta as any).postalAddress || (meta as any).postal,
+              repsEmail: (meta as any).repsEmail,
+              repsUrl: (meta as any).repsUrl,
+            })}
+          />
+        </div>
+
+        <div id="basics-section">
+          <ApplicationBasics value={basics} onChange={setBasics} />
+        </div>
+
+        <div id="activities-section">
+          <ActivitiesHours rows={activities} onChange={setActivities} />
+        </div>
       </div>
     </AppShell>
   );


### PR DESCRIPTION
## Summary
- refactor publish page layout with live preview and checklist rail
- improve upload dropzone with shimmer progress and error handling
- add copy/download notice preview component

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open './test/data/05-versions-space.pdf')*
- `npx vitest run src/components/__tests__/NoticePreview.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c1aff8e0f4833086f4de15ed4ee7ef