### PR TITLE
feat(publish): two-column layout, animated upload, live preview, actionable checklist

### DIFF
--- a/src/components/__tests__/NoticePreview.test.tsx
+++ b/src/components/__tests__/NoticePreview.test.tsx
@@ -6,7 +6,7 @@ describe('NoticePreview', () => {
   it('renders text with copy and download actions', () => {
     render(<NoticePreview text="hello" />);
     expect(screen.getByText('hello')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy text/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download \.txt/i })).toBeInTheDocument();
   });
 });

--- a/src/components/publish/ComplianceChecklist.tsx
+++ b/src/components/publish/ComplianceChecklist.tsx
@@ -55,7 +55,7 @@ export default function ComplianceChecklist({ items }: { items: ChecklistItem[] 
                 <div className="flex items-center gap-2">
                   <span
                     aria-hidden
-                    className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${item.ok ? 'bg-emerald-600 text-white' : 'bg-red-600 text-white'}`}
+                    className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${item.ok ? 'bg-emerald-600 text-white' : 'bg-amber-500 text-white'}`}
                   >
                     {item.ok ? '✔' : '✘'}
                   </span>

--- a/src/components/publish/NoticePreview.tsx
+++ b/src/components/publish/NoticePreview.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 
 export default function NoticePreview({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
+  const reduceMotion = useReducedMotion();
   const copyText = async () => {
     try {
       await navigator.clipboard?.writeText(text || '');
@@ -28,25 +29,41 @@ export default function NoticePreview({ text }: { text: string }) {
       className="rounded-2xl border bg-white p-6 md:p-8 shadow-sm"
     >
       <h3 className="mb-3 text-sm font-semibold tracking-tight">Notice preview</h3>
-      {text ? (
-        <pre className="max-h-[70vh] overflow-y-auto whitespace-pre-wrap break-words font-mono text-sm leading-relaxed">
-          {text}
-        </pre>
-      ) : (
-        <p className="text-sm text-slate-500">
-          Your notice preview will appear here after upload or as you type.
-        </p>
-      )}
+      <AnimatePresence mode="wait" initial={false}>
+        {text ? (
+          <motion.pre
+            key={text}
+            initial={{ opacity: reduceMotion ? 1 : 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: reduceMotion ? 1 : 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.2 }}
+            className="max-h-[70vh] overflow-y-auto whitespace-pre-wrap break-words font-mono text-sm leading-relaxed"
+          >
+            {text}
+          </motion.pre>
+        ) : (
+          <motion.p
+            key="placeholder"
+            initial={{ opacity: reduceMotion ? 1 : 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: reduceMotion ? 1 : 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.2 }}
+            className="text-sm text-slate-500"
+          >
+            Your notice will appear here after upload or as you type.
+          </motion.p>
+        )}
+      </AnimatePresence>
       <div className="mt-6 flex justify-end gap-2">
         <button
-          aria-label="Copy notice text"
+          aria-label="Copy text"
           className="rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           onClick={copyText}
         >
-          Copy
+          Copy text
         </button>
         <button
-          aria-label="Download notice text"
+          aria-label="Download .txt"
           className="rounded-lg px-3 py-1.5 text-sm font-medium shadow-sm hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           onClick={downloadTxt}
         >
@@ -56,10 +73,10 @@ export default function NoticePreview({ text }: { text: string }) {
       <AnimatePresence>
         {copied && (
           <motion.div
-            initial={{ opacity: 0, y: 10 }}
+            initial={{ opacity: reduceMotion ? 1 : 0, y: reduceMotion ? 0 : 10 }}
             animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 10 }}
-            transition={{ duration: 0.2 }}
+            exit={{ opacity: reduceMotion ? 1 : 0, y: reduceMotion ? 0 : 10 }}
+            transition={{ duration: reduceMotion ? 0 : 0.2 }}
             className="fixed bottom-4 right-4 rounded-md bg-slate-900 px-3 py-2 text-sm text-white shadow-lg"
             role="status"
             aria-live="polite"

--- a/src/components/publish/UploadDropzone.tsx
+++ b/src/components/publish/UploadDropzone.tsx
@@ -60,7 +60,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
     } catch (e) {
       setState('failed');
       setElapsed(performance.now() - t0);
-      setError('Upload failed. You can still edit everything manually.');
+      setError("We couldn't process this file — retry or paste text manually");
     }
   };
 
@@ -169,7 +169,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
 
       {(state === 'uploading' || state === 'ocrRunning') && (
         <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-slate-200">
-          <div className="h-full w-full bg-gradient-to-r from-blue-400 via-blue-200 to-blue-400 bg-[length:200%_100%] animate-shimmer" />
+          <div className="h-full w-full bg-gradient-to-r from-slate-200 via-slate-100 to-slate-200 bg-[length:200%_100%] animate-shimmer" />
         </div>
       )}
 

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -5,12 +5,11 @@ import ApplicantPanel from '@/components/publish/ApplicantPanel';
 import ApplicationBasics, { type ApplicationBasicsValue } from '@/components/publish/ApplicationBasics';
 import ActivitiesHours, { type ActivityRow } from '@/components/publish/ActivitiesHours';
 import ComplianceChecklist, { type ChecklistItem } from '@/components/publish/ComplianceChecklist';
-import NoticePreview from '@/components/publish/NoticePreview';
+import PublishNoticePreview from '@/components/publish/NoticePreview';
 import UploadDropzone from '@/components/publish/UploadDropzone';
 import { type PremisesData } from '@/schemas/premises';
 
 export default function PublishPage() {
-  const [noticeText, setNoticeText] = useState("");
   const [previewText, setPreviewText] = useState("");
   const [meta, setMeta] = useState<any>({});
   const [publishing, setPublishing] = useState(false);
@@ -72,7 +71,7 @@ export default function PublishPage() {
         councilName: form.councilName,
         councilEmail: form.councilEmail,
         premisesAddress: form.premisesAddress,
-        noticeText,
+        noticeText: previewText,
         source: 'upload',
         meta,
       };
@@ -107,7 +106,7 @@ export default function PublishPage() {
       onStepChange={(i) => i <= currentStep && setCurrentStep(i)}
       rail={(
         <div className="sticky top-6 space-y-4">
-          <NoticePreview text={previewText} />
+          <PublishNoticePreview text={previewText} />
           <ComplianceChecklist items={checklist} />
         </div>
       )}
@@ -144,7 +143,6 @@ export default function PublishPage() {
 
         <UploadDropzone
           onText={(t) => {
-            setNoticeText(t);
             setPreviewText(t);
           }}
           onMeta={(m) => setMeta(m)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,13 +10,13 @@ export default {
           '100%': { backgroundPosition: '200% 0%' },
         },
         shimmer: {
-          '0%': { backgroundPosition: '-200% 0%' },
-          '100%': { backgroundPosition: '200% 0%' },
+          '0%': { backgroundPosition: '0% 0' },
+          '100%': { backgroundPosition: '200% 0' },
         },
       },
       animation: {
         progress: 'progress 1.5s linear infinite',
-        shimmer: 'shimmer 1.5s linear infinite',
+        shimmer: 'shimmer 1.2s linear infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- refactor publish page to drive preview from single text state
- polish upload flow with shimmer progress, file chip and clearer errors
- add animated notice preview with copy/download actions and toast
- color-coded checklist rows with scroll-to-fix buttons

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open './test/data/05-versions-space.pdf')*
- `npx vitest run src/components/__tests__/NoticePreview.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c1b95711848330852a658d21599ef3