### PR TITLE
Add premises licence research and initial schema scaffolding

### DIFF
--- a/data/councils/authorityPacks/camden.json
+++ b/data/councils/authorityPacks/camden.json
@@ -1,0 +1,11 @@
+{
+  "id": "camden",
+  "name": "Camden Council",
+  "region": "england_wales",
+  "representation": {
+    "email": "licensing@camden.gov.uk"
+  },
+  "consultationLength": 28,
+  "headingCase": "upper",
+  "extraLines": ["Notice ID must be quoted in correspondence."]
+}

--- a/data/councils/authorityPacks/edinburgh.json
+++ b/data/councils/authorityPacks/edinburgh.json
@@ -1,0 +1,12 @@
+{
+  "id": "edinburgh",
+  "name": "City of Edinburgh Council",
+  "region": "scotland",
+  "representation": {
+    "email": "licensing@edinburgh.gov.uk",
+    "postal": "Licensing, 249 High St, Edinburgh EH1 1YJ"
+  },
+  "consultationLength": 28,
+  "headingCase": "upper",
+  "extraLines": ["PUBLIC NOTICE"]
+}

--- a/data/councils/authorityPacks/manchester.json
+++ b/data/councils/authorityPacks/manchester.json
@@ -1,0 +1,10 @@
+{
+  "id": "manchester",
+  "name": "Manchester City Council",
+  "region": "england_wales",
+  "representation": {
+    "portal": "https://licensing.manchester.gov.uk"
+  },
+  "consultationLength": 28,
+  "headingCase": "title"
+}

--- a/docs/research/notice-ecosystem.md
+++ b/docs/research/notice-ecosystem.md
@@ -1,0 +1,36 @@
+# UK Public Notice Ecosystem
+
+This note summarises other notice regimes and how a schema‑driven approach
+applies across them. Information sourced from statutory guidance and sample
+notices held internally.
+
+## Regimes overview
+
+| Regime | Statute | Typical audience | Statutory period | Key channels |
+|--------|---------|-----------------|------------------|--------------|
+| Premises Licence | Licensing Act 2003 | Local residents, businesses | 28 days | Email, portal, post |
+| Goods Vehicle Operator (GVOL) | Goods Vehicles (Licensing of Operators) Act 1995 | Residents near operating centre | 21 days | Email, post |
+| Traffic Regulation Order (TRO) | Road Traffic Regulation Act 1984 | Road users | 21 days | Web portal, post |
+| Planning | Town and Country Planning Act 1990 | Neighbours, community | 21 days | Portal, email, post |
+| Gambling | Gambling Act 2005 | Local residents | 28 days | Email, portal |
+| Insolvency/Probate/Company | Insolvency Act 1986 etc. | Creditors, claimants | 21–28 days | Email, post |
+
+## Generalisable schema concepts
+
+- **Subject** – applicant, operator, debtor, road scheme, etc.
+- **Location** – address, coordinates, map link, UPRN when relevant
+- **Activity/Proposal** – what is being licensed, restricted or notified
+- **Inspection/Information** – where supporting documents can be viewed
+- **Representation/Objection** – channels and deadline
+- **Jurisdiction pack** – region/council specific wording and contact details
+
+These elements appear in most regimes, enabling reuse of core components.
+
+## Future support assumptions
+
+- **GVOL** – will reuse premises schema with “operating centre” vocabulary and 21‑day deadline rule
+- **TRO** – location requires geometry; activities represented as “restrictions” with start/end dates
+- **Planning** – applicant and site fields plus proposal text; deadlines vary by type but follow day‑after rule
+- **Gambling** – identical to premises but with Gambling Act citations
+- **Insolvency/Probate/Company** – subject entity is person or company; deadline driven by insolvency rules
+

--- a/docs/research/premises-licence.md
+++ b/docs/research/premises-licence.md
@@ -1,0 +1,76 @@
+# Premises Licence Notice (Licensing Act 2003)
+
+This memo captures the minimum information a premises licence notice must contain
+and observations from a survey of council templates. Sources are internal GOV
+packs and publicly available council PDFs (Camden, Manchester, Edinburgh).
+
+## Mandatory lines
+
+- **Applicant/legal name** – company or individual applying
+- **Premises/trading name**
+- **Full address** – include postcode and, where known, Unique Property Reference
+  Number (UPRN)
+- **Licensable activities and opening hours** – alcohol on/off sales, late night
+  refreshment, live/recorded music, etc. Hours must state start & end per day
+- **Inspection details** – where the application can be inspected (usually the
+  council offices or website)
+- **Representation method** – email, web portal URL, or postal address for
+  objections
+- **Representation deadline** – 28 days from the day after the application date
+- **Offence warning** – “It is an offence to knowingly or recklessly make a false
+  statement in connection with an application. Those who do are liable on
+  summary conviction to a fine of up to level 5 on the standard scale.”
+- **Region‑specific lines**
+  - England & Wales – reference to Licensing Act 2003
+  - Scotland – refer to Licensing (Scotland) Act 2005 and include licensing board
+    contact
+  - Northern Ireland – Licensing (NI) Order 1996 wording and Department for
+    Communities guidance
+
+## Council wording quirks
+
+- **Channels** – some councils accept representations only by email (e.g.
+  Camden), others via web portal (Manchester) or allow postal submissions
+  (Edinburgh)
+- **Headings/casing** – Camden uses uppercase headings; Manchester uses title
+  case; Edinburgh prefixes notices with “PUBLIC NOTICE”
+- **Extra lines** – Manchester asks applicants to include the application
+  reference; Edinburgh requests the name of the local licensing board
+
+## Bank holiday adjustments
+
+The representation deadline is 28 days from the day after the application date.
+If the deadline falls on a weekend or bank holiday it moves to the next working
+ day. Example:
+
+| Application date | Day after | +28 days | Deadline (BH adj.) |
+|------------------|-----------|----------|--------------------|
+| Fri 1 Mar 2024   | Sat 2 Mar | Fri 29 Mar (Good Friday) | Tue 2 Apr 2024 |
+
+## Council templates
+
+| Council   | Representation method | Heading style | Notable wording |
+|-----------|----------------------|---------------|-----------------|
+| Camden    | Email: licensing@camden.gov.uk | UPPERCASE | Includes notice ID |
+| Manchester| Online portal URL | Title Case | Mentions web portal only |
+| Edinburgh | Email or post | "PUBLIC NOTICE" prefix | References Licensing Board |
+
+## Comparison with other notice regimes
+
+| Regime                     | Core fields                                   | Similarities to premises licence schema |
+|----------------------------|-----------------------------------------------|----------------------------------------|
+| Goods Vehicle Operator (GVOL)| Operator name, base, vehicle limit, period | Requires address, legal entity, deadlines |
+| Traffic Regulation Order (TRO)| Road name, restriction type, dates | Needs location and statutory period |
+| Planning applications       | Applicant, site address, proposal, comment deadline | Same pattern of applicant, site, deadline |
+| Gambling Act notices        | Premises, activities, inspection, reps deadline | Essentially identical schema with different activities |
+| Insolvency/Probate/Company  | Debtor/company, court ref, deadline for claims | Uses applicant, subject, deadlines |
+
+The schema can generalise by modelling:
+
+- **Subject entity** (applicant/debtor/operator)
+- **Location** (address/UPRN)
+- **Activities or proposal**
+- **Inspection/objection channels**
+- **Statutory deadline** rules
+- **Region/council‑specific wording packs**
+

--- a/schemas/noticeTypes/premises-licence.schema.test.ts
+++ b/schemas/noticeTypes/premises-licence.schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { PremisesLicenceSchema } from './premises-licence.schema';
+
+const base = {
+  applicant: 'Alice Smith',
+  premises: 'The Red Lion',
+  address: {
+    line1: '1 High St',
+    city: 'Townsville',
+    postcode: 'AB1 2CD',
+  },
+  activities: [
+    { type: 'alcohol_on', days: ['Mon'], start: '10:00', end: '22:00' },
+  ],
+  applicationDate: '2024-01-10',
+  council: 'camden',
+  region: 'england_wales',
+  representation: { method: 'email', value: 'licensing@camden.gov.uk' },
+};
+
+describe('PremisesLicenceSchema', () => {
+  it('accepts valid data', () => {
+    const parsed = PremisesLicenceSchema.parse(base);
+    expect(parsed.applicant).toBe('Alice Smith');
+  });
+
+  it('requires applicant', () => {
+    const res = PremisesLicenceSchema.safeParse({ ...base, applicant: '' });
+    expect(res.success).toBe(false);
+  });
+
+  it('requires at least one activity', () => {
+    const res = PremisesLicenceSchema.safeParse({ ...base, activities: [] });
+    expect(res.success).toBe(false);
+  });
+});

--- a/schemas/noticeTypes/premises-licence.schema.ts
+++ b/schemas/noticeTypes/premises-licence.schema.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+// Days of week
+const DAY = z.enum(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+
+// Activities that require hours
+export const Activity = z.object({
+  type: z.enum([
+    'alcohol_on',
+    'alcohol_off',
+    'alcohol_on_off',
+    'late_night_refreshment',
+    'live_music',
+    'recorded_music',
+  ]),
+  days: z.array(DAY).nonempty(),
+  start: z.string().regex(/^\d{2}:\d{2}$/),
+  end: z.string().regex(/^\d{2}:\d{2}$/),
+});
+
+export const Activities = z.array(Activity).min(1);
+
+export const Address = z.object({
+  line1: z.string().min(1),
+  line2: z.string().optional(),
+  city: z.string().min(1),
+  postcode: z.string().min(1),
+  uprn: z.string().optional(),
+});
+
+export const Representation = z.object({
+  method: z.enum(['email', 'portal', 'post']),
+  value: z.string().min(1),
+});
+
+export const PremisesLicenceSchema = z.object({
+  applicant: z.string().min(1),
+  premises: z.string().min(1),
+  address: Address,
+  activities: Activities,
+  applicationDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/), // ISO date
+  council: z.string().min(1),
+  region: z.enum(['england_wales', 'scotland', 'northern_ireland']),
+  representation: Representation,
+});
+
+export type PremisesLicence = z.infer<typeof PremisesLicenceSchema>;

--- a/schemas/rules/premises-licence.rules.test.ts
+++ b/schemas/rules/premises-licence.rules.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { computeRepresentationDeadline, validatePremisesLicence } from './premises-licence.rules';
+import { PremisesLicence } from '../noticeTypes/premises-licence.schema';
+
+const base: PremisesLicence = {
+  applicant: 'Alice Smith',
+  premises: 'The Red Lion',
+  address: {
+    line1: '1 High St',
+    city: 'Townsville',
+    postcode: 'AB1 2CD',
+  },
+  activities: [
+    { type: 'alcohol_on', days: ['Mon'], start: '10:00', end: '22:00' },
+  ],
+  applicationDate: '2024-03-01',
+  council: 'camden',
+  region: 'england_wales',
+  representation: { method: 'email', value: 'licensing@camden.gov.uk' },
+};
+
+describe('premises licence rules', () => {
+  it('computes representation deadline with bank holidays', () => {
+    const deadline = computeRepresentationDeadline(base.applicationDate, [
+      '2024-03-29',
+      '2024-04-01',
+    ]);
+    expect(deadline).toBe('2024-04-02');
+  });
+
+  it('flags invalid activity hours', () => {
+    const bad: PremisesLicence = {
+      ...base,
+      activities: [{ type: 'alcohol_on', days: ['Mon'], start: '10:00', end: '10:00' }],
+    };
+    const result = validatePremisesLicence(bad);
+    expect(result.issues).toContain('Activity 1 has invalid hours');
+  });
+
+  it('returns computed deadline', () => {
+    const result = validatePremisesLicence(base, ['2024-03-29', '2024-04-01']);
+    expect(result.representationDeadline).toBe('2024-04-02');
+    expect(result.issues.length).toBe(0);
+  });
+});

--- a/schemas/rules/premises-licence.rules.ts
+++ b/schemas/rules/premises-licence.rules.ts
@@ -1,0 +1,55 @@
+import { PremisesLicence } from '../noticeTypes/premises-licence.schema';
+
+function parseTime(t: string): number {
+  const [hh, mm] = t.split(':').map(Number);
+  return hh * 60 + mm;
+}
+
+export function computeRepresentationDeadline(
+  applicationDate: string,
+  bankHolidays: string[] = []
+): string {
+  const app = new Date(applicationDate);
+  const start = new Date(app.getFullYear(), app.getMonth(), app.getDate() + 1);
+  const deadline = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 28);
+  const holidaySet = new Set(bankHolidays);
+  while (
+    deadline.getDay() === 0 ||
+    deadline.getDay() === 6 ||
+    holidaySet.has(deadline.toISOString().slice(0, 10))
+  ) {
+    deadline.setDate(deadline.getDate() + 1);
+  }
+  return deadline.toISOString().slice(0, 10);
+}
+
+export function validatePremisesLicence(
+  data: PremisesLicence,
+  bankHolidays: string[] = []
+): { representationDeadline: string; issues: string[] } {
+  const issues: string[] = [];
+
+  if (!data.activities.length) {
+    issues.push('At least one licensable activity is required');
+  }
+
+  data.activities.forEach((a, idx) => {
+    const s = parseTime(a.start);
+    const e = parseTime(a.end);
+    if (s === e) {
+      issues.push(`Activity ${idx + 1} has invalid hours`);
+      return;
+    }
+    const duration = (e <= s ? e + 24 * 60 : e) - s;
+    if (duration <= 0 || duration >= 24 * 60) {
+      issues.push(`Activity ${idx + 1} has invalid hours`);
+    }
+  });
+
+  const representationDeadline = computeRepresentationDeadline(
+    data.applicationDate,
+    bankHolidays
+  );
+
+  return { representationDeadline, issues };
+}

--- a/templates/premises-licence.template.ts
+++ b/templates/premises-licence.template.ts
@@ -1,0 +1,45 @@
+import { PremisesLicence } from '../schemas/noticeTypes/premises-licence.schema';
+import { computeRepresentationDeadline } from '../schemas/rules/premises-licence.rules';
+
+export interface CouncilStyle {
+  headingCase?: 'upper' | 'title';
+  region: 'england_wales' | 'scotland' | 'northern_ireland';
+  bankHolidays?: string[];
+  extraLines?: string[];
+}
+
+function formatHeading(style: CouncilStyle): string {
+  const base =
+    style.region === 'scotland'
+      ? 'Licensing (Scotland) Act 2005'
+      : 'Licensing Act 2003';
+  return style.headingCase === 'upper' ? base.toUpperCase() : base;
+}
+
+export function renderPremisesLicence(
+  data: PremisesLicence,
+  council: CouncilStyle
+): string {
+  const deadline = computeRepresentationDeadline(
+    data.applicationDate,
+    council.bankHolidays
+  );
+  const lines: string[] = [];
+  lines.push(formatHeading(council));
+  lines.push(
+    `${data.applicant} has applied for a premises licence for ${data.premises}, ${data.address.line1}, ${data.address.city} ${data.address.postcode}.`
+  );
+  lines.push('Licensable activities and hours:');
+  data.activities.forEach((a) => {
+    const days = a.days.join(', ');
+    lines.push(`- ${a.type.replace(/_/g, ' ')}: ${days} ${a.start}–${a.end}`);
+  });
+  lines.push(
+    `Representations must be made by ${deadline} via ${data.representation.method}: ${data.representation.value}.`
+  );
+  lines.push(
+    'It is an offence to knowingly or recklessly make a false statement in connection with an application. Those who do are liable on summary conviction to a fine of up to level 5 on the standard scale.'
+  );
+  if (council.extraLines) lines.push(...council.extraLines);
+  return lines.join('\n');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
     globals: true,
     passWithNoTests: false,
     setupFiles: ['./src/setupTests.ts'],
-    include: ['src/**/*.{test,spec}.ts?(x)', 'server/**/*.{test,spec}.ts'],
+    include: [
+      'src/**/*.{test,spec}.ts?(x)',
+      'schemas/**/*.{test,spec}.ts?(x)',
+      'server/**/*.{test,spec}.ts',
+    ],
     coverage: {
       provider: 'v8',
       reportsDirectory: './coverage',


### PR DESCRIPTION
## Summary
- document premises licence requirements and wider notice ecosystem
- scaffold schema, rules, template and council authority packs for premises licence notices
- add unit tests for schema and deadline rules

## Testing
- `npx vitest run schemas/noticeTypes/premises-licence.schema.test.ts schemas/rules/premises-licence.rules.test.ts`
- `npm test` *(fails: UploadDropzone scrollIntoView not a function; missing test fixture; unrelated existing tests fail)*
- `npm run lint` *(fails: parserOptions.project missing for some files)*


------
https://chatgpt.com/codex/tasks/task_e_68c1d7b9c67c83309da4ca39244de7a5