### PR TITLE
refactor publish layout

### DIFF
--- a/docs/progress/publish-overhaul.md
+++ b/docs/progress/publish-overhaul.md
@@ -16,3 +16,8 @@
 - [x] Accessibility error summary – `src/components/publish/ErrorSummary.tsx`, `GVOLForm.tsx`, `TrafficForm.tsx`
 - [x] Documentation & progress log – `docs/progress/publish-overhaul.md`
 - [x] Publish page wiring – `src/pages/publish/index.tsx`
+
+## 2024-xx updates
+
+- [x] Grid layout and right rail cards – `src/pages/publish/index.tsx`
+- [x] Notice form switching test – `src/components/__tests__/NoticeTypeSelect.test.tsx`

--- a/src/components/__tests__/NoticeTypeSelect.test.tsx
+++ b/src/components/__tests__/NoticeTypeSelect.test.tsx
@@ -1,13 +1,21 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import NoticeTypeSelect from '../publish/NoticeTypeSelect';
 import React from 'react';
-import { vi } from 'vitest';
+import PublishPage from '@/pages/publish';
 
 describe('NoticeTypeSelect', () => {
-  it('switches types', () => {
-    const onChange = vi.fn();
-    render(<NoticeTypeSelect value="premises" onChange={onChange} />);
+  it('renders only the active form when switching types', () => {
+    render(<PublishPage />);
+
+    // Premises by default
+    expect(screen.getByLabelText('Premises name')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Operator')).not.toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'gvol' } });
-    expect(onChange).toHaveBeenCalledWith('gvol');
+    expect(screen.getByLabelText('Operator')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Premises name')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'traffic' } });
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Operator')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -1,13 +1,13 @@
 import { useRef, useState } from 'react';
-import type { AddressOption } from '@/components/AddressAutocomplete';
-import AppShell from '@/components/publish/AppShell';
-import ApplicantPanel from '@/components/publish/ApplicantPanel';
 import NoticeTypeSelect, { type NoticeType } from '@/components/publish/NoticeTypeSelect';
 import PremisesForm from '@/components/publish/PremisesForm';
 import GVOLForm from '@/components/publish/GVOLForm';
 import TrafficForm from '@/components/publish/TrafficForm';
-import RightRail from '@/components/publish/RightRail';
 import ErrorSummary from '@/components/publish/ErrorSummary';
+import PreviewCard from '@/components/publish/RightRail/PreviewCard';
+import ComplianceCard from '@/components/publish/RightRail/ComplianceCard';
+import KeyDatesCard from '@/components/publish/RightRail/KeyDatesCard';
+import CostCard from '@/components/publish/RightRail/CostCard';
 import { renderPremisesLicence } from '../../../templates/premises-licence.template';
 import { renderGVOL } from '../../../templates/gvol.template';
 import { renderTrafficOrder } from '../../../templates/traffic-order.template';
@@ -22,46 +22,16 @@ export default function PublishPage() {
   const [representationDeadline, setRepresentationDeadline] = useState('');
   const autoFocusRef = useRef<HTMLInputElement>(null);
 
-  const [applicant, setApplicant] = useState({
-    applicantName: '',
-    applicantEmail: '',
-    councilName: '',
-    councilEmail: '',
-    address: { line1: '', city: '', postcode: '', uprn: '' },
-    region: '',
-    representationEmail: '',
-    representationUrl: '',
-    representationPostal: '',
-    consultationDays: 0,
-  });
-
-  const patchApplicant = (patch: Partial<typeof applicant>) =>
-    setApplicant((a) => ({ ...a, ...patch }));
-
-  const handleAddress = (a: AddressOption) => {
-    setApplicant((f) => ({
-      ...f,
-      address: {
-        line1: a.line1 || a.lines?.[0] || '',
-        line2: a.line2 || a.lines?.[1],
-        line3: a.line3 || a.lines?.[2],
-        city: a.city || a.town || '',
-        postcode: a.postcode || '',
-        uprn: a.uprn,
-      },
-    }));
-  };
-
   const handlePremisesSubmit = async (data: any) => {
     const payload: any = {
       applicant: data.applicantName,
       premises: data.premisesName,
-      address: { line1: data.premisesAddress, city: '', postcode: '', uprn: applicant.address.uprn },
+      address: { line1: data.premisesAddress, city: '', postcode: '', uprn: data.uprn },
       activities: [],
       applicationDate: new Date().toISOString().slice(0, 10),
       council: data.councilName,
-      region: applicant.region || 'england_wales',
-      representation: { method: 'email', value: data.councilEmail || applicant.representationEmail },
+      region: 'england_wales',
+      representation: { method: 'email', value: data.councilEmail },
     };
     const { issues, representationDeadline } = validatePremisesLicence(payload as any);
     setPreview(renderPremisesLicence(payload as any, { region: payload.region }));
@@ -72,20 +42,20 @@ export default function PublishPage() {
   const handleGVOLSubmit = async (data: any) => {
     const payload: any = {
       operator: data.operator,
-      address: applicant.address,
+      address: data.address,
       vehicles: data.vehicles,
       trailers: data.trailers,
       applicationDate: new Date().toISOString().slice(0, 10),
-      council: applicant.councilName,
-      region: applicant.region || 'england_wales',
+      council: data.councilName,
+      region: 'england_wales',
     };
     const { issues, representationDeadline } = validateGVOL(payload as any);
     setPreview(
       renderGVOL(payload as any, {
         id: '',
-        name: applicant.councilName,
+        name: data.councilName,
         region: payload.region,
-        representation: { email: applicant.representationEmail || applicant.councilEmail },
+        representation: { email: data.councilEmail },
       } as any),
     );
     setIssues(issues);
@@ -98,16 +68,16 @@ export default function PublishPage() {
       restriction: data.description,
       duration: '',
       applicationDate: new Date().toISOString().slice(0, 10),
-      council: applicant.councilName,
-      region: applicant.region || 'england_wales',
+      council: data.councilName,
+      region: 'england_wales',
     };
     const { issues, representationDeadline } = validateTrafficOrder(payload as any);
     setPreview(
       renderTrafficOrder(payload as any, {
         id: '',
-        name: applicant.councilName,
+        name: data.councilName,
         region: payload.region,
-        representation: { email: applicant.representationEmail || applicant.councilEmail },
+        representation: { email: data.councilEmail },
       } as any),
     );
     setIssues(issues);
@@ -115,27 +85,10 @@ export default function PublishPage() {
   };
 
   return (
-    <AppShell
-      title="Publish a Notice"
-      rail={<RightRail preview={preview} issues={issues} representationDeadline={representationDeadline} cost={49.99} />}
-    >
-      <div className="space-y-6">
+    <div className="grid grid-cols-[minmax(0,720px),340px] gap-8">
+      <main className="space-y-6">
         <ErrorSummary errors={issues} />
         <NoticeTypeSelect value={noticeType} onChange={setNoticeType} />
-        <ApplicantPanel
-          applicantName={applicant.applicantName}
-          applicantEmail={applicant.applicantEmail}
-          councilName={applicant.councilName}
-          councilEmail={applicant.councilEmail}
-          address={applicant.address}
-          region={applicant.region}
-          representationEmail={applicant.representationEmail}
-          representationUrl={applicant.representationUrl}
-          representationPostal={applicant.representationPostal}
-          consultationDays={applicant.consultationDays}
-          onPatch={patchApplicant}
-          onSelectAddress={handleAddress}
-        />
         {noticeType === 'premises' && (
           <PremisesForm onSubmit={handlePremisesSubmit} saving={false} autoFocusRef={autoFocusRef} />
         )}
@@ -145,7 +98,13 @@ export default function PublishPage() {
         {noticeType === 'traffic' && (
           <TrafficForm onSubmit={handleTrafficSubmit} saving={false} autoFocusRef={autoFocusRef} />
         )}
-      </div>
-    </AppShell>
+      </main>
+      <aside className="sticky top-6 w-[340px] space-y-4">
+        <PreviewCard text={preview} />
+        <ComplianceCard issues={issues} />
+        <KeyDatesCard representationDeadline={representationDeadline} />
+        <CostCard cost={49.99} />
+      </aside>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor /publish page to use grid layout with fixed right rail cards
- remove legacy applicant panel and show only active notice form
- add regression test verifying notice form switching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26c9aa65c8330a3cf279c09f59a49