### PR TITLE
Guard against merge markers and enhance address autocomplete

### DIFF
--- a/docs/progress/publish-overhaul.md
+++ b/docs/progress/publish-overhaul.md
@@ -21,3 +21,5 @@
 
 - [x] Grid layout and right rail cards – `src/pages/publish/index.tsx`
 - [x] Notice form switching test – `src/components/__tests__/NoticeTypeSelect.test.tsx`
+- [x] Merge conflict guard – `src/components/__tests__/no-merge-markers.test.ts`
+- [x] Address UPRN chip – `src/components/AddressAutocomplete.tsx`, `src/components/__tests__/AddressAutocomplete.test.tsx`

--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import AsyncCombobox from "./AsyncCombobox";
 
 // Broader type to satisfy page contract while keeping compat with combobox
@@ -32,6 +32,8 @@ export function mapAddress(r: any): AddressOption {
 }
 
 export default function AddressAutocomplete({ onSelect }: { onSelect: (a: AddressOption) => void }) {
+  const [selected, setSelected] = useState<AddressOption | null>(null);
+
   const fetchOptions = async (q: string) => {
     const res = await fetch(`/api/address/search?q=${encodeURIComponent(q)}`);
     if (!res.ok) return [];
@@ -41,15 +43,27 @@ export default function AddressAutocomplete({ onSelect }: { onSelect: (a: Addres
     return results.map(mapAddress) as AddressOption[];
   };
   return (
-    <AsyncCombobox<AddressOption>
-      label="Premises Address"
-      placeholder="Start typing an address…"
-      fetchOptions={fetchOptions}
-      onSelect={onSelect}
-      getOptionLabel={(o) => o.label || [o.line1, o.city ?? o.town, o.postcode].filter(Boolean).join(", ")}
-      getKey={(o) => o.id || o.label || `${o.line1}-${o.postcode}`}
-      required
-      inputTestId="address-input"
-    />
+    <div>
+      <AsyncCombobox<AddressOption>
+        label="Premises Address"
+        placeholder="Start typing an address…"
+        fetchOptions={fetchOptions}
+        onSelect={(opt) => {
+          setSelected(opt);
+          onSelect(opt);
+        }}
+        getOptionLabel={(o) =>
+          o.label || [o.line1, o.city ?? o.town, o.postcode].filter(Boolean).join(", ")
+        }
+        getKey={(o) => o.id || o.label || `${o.line1}-${o.postcode}`}
+        required
+        inputTestId="address-input"
+      />
+      {selected?.uprn && (
+        <span className="mt-1 inline-block rounded bg-green-100 px-2 py-0.5 text-xs text-green-800" data-testid="uprn-chip">
+          UPRN saved
+        </span>
+      )}
+    </div>
   );
 }

--- a/src/components/__tests__/AddressAutocomplete.test.ts
+++ b/src/components/__tests__/AddressAutocomplete.test.ts
@@ -1,9 +1,0 @@
-import { describe, it, expect } from 'vitest';
-import { mapAddress } from '../AddressAutocomplete';
-
-describe('mapAddress', () => {
-  it('maps uprn', () => {
-    const mapped = mapAddress({ line1: '1 High St', city: 'Town', postcode: 'AB1', uprn: '123' });
-    expect(mapped.uprn).toBe('123');
-  });
-});

--- a/src/components/__tests__/AddressAutocomplete.test.tsx
+++ b/src/components/__tests__/AddressAutocomplete.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AddressAutocomplete, { mapAddress } from '../AddressAutocomplete';
+
+describe('mapAddress', () => {
+  it('maps uprn', () => {
+    const mapped = mapAddress({ line1: '1 High St', city: 'Town', postcode: 'AB1', uprn: '123' });
+    expect(mapped.uprn).toBe('123');
+  });
+});
+
+describe('AddressAutocomplete', () => {
+  it('fetches results for partial query', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results: [] }) } as any);
+    // @ts-ignore
+    global.fetch = fetchMock;
+    render(<AddressAutocomplete onSelect={() => {}} />);
+    const input = screen.getByTestId('address-input');
+    await userEvent.type(input, '9 lower park');
+    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/address/search?q=9%20lower%20park'));
+  });
+
+  it('stores UPRN when selecting a postcode result', async () => {
+    const results = [{ id: '1', label: '1 High St', uprn: '999', postcode: 'AB1 2CD' }];
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ results }) } as any);
+    // @ts-ignore
+    global.fetch = fetchMock;
+    const onSelect = vi.fn();
+    render(<AddressAutocomplete onSelect={onSelect} />);
+    const input = screen.getByTestId('address-input');
+    await userEvent.type(input, 'AB1 2CD');
+    await new Promise((r) => setTimeout(r, 350));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await waitFor(() => screen.getByText('1 High St'));
+    await userEvent.click(screen.getByText('1 High St'));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ uprn: '999' }));
+    expect(screen.getByTestId('uprn-chip')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/no-merge-markers.test.ts
+++ b/src/components/__tests__/no-merge-markers.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+function gather(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...gather(full));
+    } else if (['.ts', '.tsx'].includes(extname(entry))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+describe('no merge markers', () => {
+  const files = [...gather('src'), ...gather('templates')].filter(
+    (f) => !f.endsWith('no-merge-markers.test.ts')
+  );
+  files.forEach((file) => {
+    it(`${file} has no conflict markers`, () => {
+      const content = readFileSync(file, 'utf8');
+      expect(content).not.toMatch(/<<<<<<<|=======|>>>>>>>/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add sticky chip to show when UPRN stored from address search
- verify address lookup fetches queries and retains UPRN
- ensure repository remains free of merge conflict markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c271e66b1083308338ae264a9456a2