### PR TITLE
style: theme publish page

### DIFF
--- a/docs/progress/publish-overhaul.md
+++ b/docs/progress/publish-overhaul.md
@@ -29,3 +29,4 @@
 - [x] Key dates tooltip & cost override – `src/components/publish/RightRail/KeyDatesCard.tsx`, `src/pages/publish/index.tsx`
 - [x] Activities grid overflow guard – `src/components/publish/ActivitiesHoursGrid.tsx`
 - [x] Layout & preview tests – `src/components/__tests__/{PublishLayout,PreviewTemplate,ActivitiesHoursGrid,ErrorSummary}.test.tsx`
+- [x] Design system tokens + /publish theming applied – `src/styles/ui.ts`, `tailwind.config.js`, `src/pages/publish/index.tsx`, `src/components/publish/{PremisesForm,GVOLForm,TrafficForm,ActivitiesHoursGrid,NoticeTypeSelect,ErrorSummary.tsx,RightRail/PreviewCard.tsx}`

--- a/src/components/__tests__/PublishLayout.test.tsx
+++ b/src/components/__tests__/PublishLayout.test.tsx
@@ -17,7 +17,7 @@ describe('Publish layout', () => {
 
     // grid layout applied
     const layout = screen.getByTestId('publish-layout');
-    expect(layout.className).toContain('grid-cols-[minmax(0,720px),340px]');
+    expect(layout.className).toContain('md:grid-cols-3');
 
     // switch form
     fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'gvol' } });

--- a/src/components/publish/ActivitiesHoursGrid.tsx
+++ b/src/components/publish/ActivitiesHoursGrid.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as UI from '@/styles/ui';
 
 const DAYS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'] as const;
 const ACTIVITIES: {key: ActivityKey; label: string}[] = [
@@ -70,11 +71,11 @@ export default function ActivitiesHoursGrid({ value, onChange }: ActivitiesHours
   };
 
   return (
-    <div className="rounded-2xl border border-slate-200 p-4 space-y-4" data-testid="activities-grid" id="activities-grid" tabIndex={-1}>
-      <h2 className="text-lg font-medium">Activities & hours</h2>
-      <div className="overflow-x-auto">
+    <div className="space-y-4" data-testid="activities-grid" id="activities-grid" tabIndex={-1}>
+      <h2 className={UI.h2}>Activities & hours</h2>
+      <div className="overflow-x-auto rounded-xl border border-slate-200 shadow-card">
       <table className="w-full min-w-[600px] text-sm">
-        <thead className="text-left text-slate-600">
+        <thead className="sticky top-0 bg-white z-10 text-left text-slate-600">
           <tr>
             <th className="py-2 pr-3">Activity</th>
             {DAYS.map((d) => (
@@ -96,14 +97,14 @@ export default function ActivitiesHoursGrid({ value, onChange }: ActivitiesHours
                         type="time"
                         aria-label={`${d} start`}
                         value={h?.start || ''}
-                        className="w-24 rounded border-slate-300"
+                        className={UI.input + ' w-24 text-sm'}
                         onChange={(e) => setCell(i, d, { start: e.target.value, end: h?.end || '' })}
                       />
                       <input
                         type="time"
                         aria-label={`${d} end`}
                         value={h?.end || ''}
-                        className="w-24 rounded border-slate-300"
+                        className={UI.input + ' w-24 text-sm'}
                         onChange={(e) => setCell(i, d, { start: h?.start || '', end: e.target.value })}
                       />
                       {cellWarning(h) && (
@@ -115,10 +116,10 @@ export default function ActivitiesHoursGrid({ value, onChange }: ActivitiesHours
               })}
               <td className="py-2 px-2">
                 <div className="flex flex-col gap-1">
-                  <button type="button" className="text-xs underline" onClick={() => copyMonToThu(i)}>
+                  <button type="button" className={UI.ghostPill + ' text-xs'} onClick={() => copyMonToThu(i)}>
                     Copy Mon→Thu
                   </button>
-                  <button type="button" className="text-xs underline" onClick={() => closeAll(i)}>
+                  <button type="button" className={UI.ghostPill + ' text-xs'} onClick={() => closeAll(i)}>
                     Closed all day
                   </button>
                 </div>

--- a/src/components/publish/ErrorSummary.tsx
+++ b/src/components/publish/ErrorSummary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as UI from '@/styles/ui';
 
 export type ErrorItem = { field: string; message: string };
 
@@ -6,14 +7,14 @@ export default function ErrorSummary({ errors }: { errors: ErrorItem[] }) {
   if (!errors.length) return null;
   return (
     <div
-      className="mb-4 border-l-4 border-rose-600 bg-rose-50 p-4"
+      className={UI.card + ' mb-4 border-red-200 bg-red-50 p-4 text-red-800'}
       role="alert"
       aria-labelledby="error-summary-title"
     >
-      <h2 id="error-summary-title" className="font-medium text-rose-700 mb-2">
+      <h2 id="error-summary-title" className="mb-2 font-semibold">
         There is a problem
       </h2>
-      <ul className="list-disc pl-5 text-sm text-rose-700">
+      <ul className="list-disc pl-5 text-sm space-y-1">
         {errors.map((e) => (
           <li key={e.field}>
             <a

--- a/src/components/publish/GVOLForm.tsx
+++ b/src/components/publish/GVOLForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ErrorSummary, { type ErrorItem } from '@/components/publish/ErrorSummary';
 import { listAuthorityPacks, type AuthorityPack } from '@/lib/authorityPacks';
+import * as UI from '@/styles/ui';
 
 interface FormData {
   operator: string;
@@ -17,8 +18,6 @@ interface Props {
   autoFocusRef: React.RefObject<HTMLInputElement>;
   onAuthorityChange?: (pack: AuthorityPack | null) => void;
 }
-
-const inputClass = 'h-10 px-3 rounded-lg border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-600';
 
 export default function GVOLForm({ onSubmit, saving, autoFocusRef, onAuthorityChange }: Props) {
   const [form, setForm] = useState<FormData>({
@@ -79,20 +78,20 @@ export default function GVOLForm({ onSubmit, saving, autoFocusRef, onAuthorityCh
     <form onSubmit={submit} className="space-y-6" aria-describedby="gvol-desc">
       <ErrorSummary errors={errors} />
 
-      <div className="rounded-2xl border p-4 space-y-4">
-        <h2 className="text-lg font-medium">Applicant & Council</h2>
+      <section className={UI.section}>
+        <div className={UI.h2}>Applicant & Council</div>
         <div className="grid grid-cols-2 gap-4">
           <div className="col-span-2">
-            <label htmlFor="applicantEmail" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="applicantEmail" className={UI.label}>
               Applicant email
             </label>
-            <input id="applicantEmail" ref={autoFocusRef} type="email" value={form.applicantEmail} onChange={(e) => setField('applicantEmail', e.target.value)} className={inputClass + ' w-full'} />
+            <input id="applicantEmail" ref={autoFocusRef} type="email" value={form.applicantEmail} onChange={(e) => setField('applicantEmail', e.target.value)} className={UI.input + ' w-full'} />
           </div>
           <div>
-            <label htmlFor="council" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="council" className={UI.label}>
               Council
             </label>
-            <select id="council" value={form.councilPack} onChange={(e) => selectPack(e.target.value)} className={inputClass}>
+            <select id="council" value={form.councilPack} onChange={(e) => selectPack(e.target.value)} className={UI.input}>
               <option value="">Select council</option>
               {packs.map((p) => (
                 <option key={p.id} value={p.id}>
@@ -102,7 +101,7 @@ export default function GVOLForm({ onSubmit, saving, autoFocusRef, onAuthorityCh
             </select>
           </div>
           <div>
-            <label htmlFor="councilEmail" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="councilEmail" className={UI.label}>
               Council email
             </label>
             <input
@@ -110,7 +109,7 @@ export default function GVOLForm({ onSubmit, saving, autoFocusRef, onAuthorityCh
               type="email"
               value={form.councilEmail}
               onChange={(e) => setField('councilEmail', e.target.value)}
-              className={inputClass}
+              className={UI.input}
             />
             {pack && (
               <p className="mt-1 text-xs text-slate-500">
@@ -120,33 +119,33 @@ export default function GVOLForm({ onSubmit, saving, autoFocusRef, onAuthorityCh
             )}
           </div>
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-2xl border p-4 space-y-4">
-        <h2 className="text-lg font-medium">Application basics</h2>
+      <section className={UI.section}>
+        <div className={UI.h2}>Application basics</div>
         <div className="grid grid-cols-2 gap-4">
           <div className="col-span-2">
-            <label htmlFor="operator" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="operator" className={UI.label}>
               Operator
             </label>
-            <input id="operator" value={form.operator} onChange={(e) => setField('operator', e.target.value)} className={inputClass + ' w-full'} />
+            <input id="operator" value={form.operator} onChange={(e) => setField('operator', e.target.value)} className={UI.input + ' w-full'} />
           </div>
           <div>
-            <label htmlFor="vehicles" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="vehicles" className={UI.label}>
               Vehicles
             </label>
-            <input id="vehicles" type="number" value={form.vehicles} onChange={(e) => setField('vehicles', Number(e.target.value))} className={inputClass} />
+            <input id="vehicles" type="number" value={form.vehicles} onChange={(e) => setField('vehicles', Number(e.target.value))} className={UI.input} />
           </div>
           <div>
-            <label htmlFor="trailers" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="trailers" className={UI.label}>
               Trailers
             </label>
-            <input id="trailers" type="number" value={form.trailers} onChange={(e) => setField('trailers', Number(e.target.value))} className={inputClass} />
+            <input id="trailers" type="number" value={form.trailers} onChange={(e) => setField('trailers', Number(e.target.value))} className={UI.input} />
           </div>
         </div>
-      </div>
+      </section>
 
-      <button type="submit" disabled={saving} className="h-10 px-4 rounded-lg bg-blue-600 text-white disabled:opacity-50">
+      <button type="submit" disabled={saving} className={UI.pillBtn}>
         {saving ? 'Saving…' : 'Submit'}
       </button>
     </form>

--- a/src/components/publish/NoticeTypeSelect.tsx
+++ b/src/components/publish/NoticeTypeSelect.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as UI from '@/styles/ui';
 
 export type NoticeType = 'premises' | 'traffic' | 'gvol';
 
@@ -15,23 +16,18 @@ const options: { value: NoticeType; label: string }[] = [
 
 export default function NoticeTypeSelect({ value, onChange }: Props) {
   return (
-    <div className="space-y-2">
-      <label htmlFor="notice-type" className="block text-sm font-medium text-slate-700">
-        What type of notice do you require?
-      </label>
-      <select
-        id="notice-type"
-        value={value}
-        onChange={(e) => onChange(e.target.value as NoticeType)}
-        className="w-full rounded border border-slate-300 p-2 bg-white"
-      >
-        <option value="">Select an option</option>
-        {options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-    </div>
+    <select
+      id="notice-type"
+      value={value}
+      onChange={(e) => onChange(e.target.value as NoticeType)}
+      className={UI.input + ' w-full'}
+    >
+      <option value="">Select an option</option>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
   );
 }

--- a/src/components/publish/PremisesForm.tsx
+++ b/src/components/publish/PremisesForm.tsx
@@ -3,6 +3,7 @@ import AddressAutocomplete, { type AddressOption } from '@/components/AddressAut
 import ActivitiesHoursGrid, { defaultGrid, type GridRow } from '@/components/publish/ActivitiesHoursGrid';
 import ErrorSummary, { type ErrorItem } from '@/components/publish/ErrorSummary';
 import { listAuthorityPacks, type AuthorityPack } from '@/lib/authorityPacks';
+import * as UI from '@/styles/ui';
 
 interface FormData {
   applicantName: string;
@@ -19,8 +20,6 @@ interface Props {
   autoFocusRef: React.RefObject<HTMLInputElement>;
   onAuthorityChange?: (pack: AuthorityPack | null) => void;
 }
-
-const inputClass = 'h-10 px-3 rounded-lg border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-600';
 
 export default function PremisesForm({ onSubmit, saving, autoFocusRef, onAuthorityChange }: Props) {
   const [form, setForm] = useState<FormData>({
@@ -91,20 +90,20 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef, onAuthori
     <form onSubmit={handleSubmit} className="space-y-6">
       <ErrorSummary errors={errors} />
 
-      <div className="rounded-2xl border p-4 space-y-4">
-        <h2 className="text-lg font-medium">Applicant & Council</h2>
+      <section className={UI.section}>
+        <div className={UI.h2}>Applicant & Council</div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label htmlFor="applicantName" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="applicantName" className={UI.label}>
               Applicant name
             </label>
-            <input id="applicantName" ref={autoFocusRef} value={form.applicantName} onChange={(e) => setField('applicantName', e.target.value)} className={inputClass} />
+            <input id="applicantName" ref={autoFocusRef} value={form.applicantName} onChange={(e) => setField('applicantName', e.target.value)} className={UI.input} />
           </div>
           <div>
-            <label htmlFor="council" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="council" className={UI.label}>
               Council
             </label>
-            <select id="council" value={form.councilPack} onChange={(e) => selectPack(e.target.value)} className={inputClass}>
+            <select id="council" value={form.councilPack} onChange={(e) => selectPack(e.target.value)} className={UI.input}>
               <option value="">Select council</option>
               {packs.map((p) => (
                 <option key={p.id} value={p.id}>
@@ -114,14 +113,14 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef, onAuthori
             </select>
           </div>
           <div className="col-span-2">
-            <label htmlFor="councilEmail" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="councilEmail" className={UI.label}>
               Council email
             </label>
             <input
               id="councilEmail"
               value={form.councilEmail}
               onChange={(e) => setField('councilEmail', e.target.value)}
-              className={inputClass + ' w-full'}
+              className={UI.input + ' w-full'}
             />
             {pack && (
               <p className="mt-1 text-xs text-slate-500">
@@ -131,28 +130,28 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef, onAuthori
             )}
           </div>
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-2xl border p-4 space-y-4">
-        <h2 className="text-lg font-medium">Application basics</h2>
+      <section className={UI.section}>
+        <div className={UI.h2}>Application basics</div>
         <div className="grid grid-cols-2 gap-4">
           <div className="col-span-2">
-            <label htmlFor="premisesName" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="premisesName" className={UI.label}>
               Premises name
             </label>
-            <input id="premisesName" value={form.premisesName} onChange={(e) => setField('premisesName', e.target.value)} className={inputClass + ' w-full'} />
+            <input id="premisesName" value={form.premisesName} onChange={(e) => setField('premisesName', e.target.value)} className={UI.input + ' w-full'} />
           </div>
           <div className="col-span-2" id="premises-address">
             <AddressAutocomplete onSelect={(a) => setField('address', a)} />
           </div>
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-2xl border p-4 space-y-4">
+      <section className={UI.section}>
         <ActivitiesHoursGrid value={form.activities} onChange={(rows) => setField('activities', rows)} />
-      </div>
+      </section>
 
-      <button type="submit" disabled={saving} className="h-10 px-4 rounded-lg bg-blue-600 text-white disabled:opacity-50">
+      <button type="submit" disabled={saving} className={UI.pillBtn}>
         {saving ? 'Saving…' : 'Submit'}
       </button>
     </form>

--- a/src/components/publish/RightRail/PreviewCard.tsx
+++ b/src/components/publish/RightRail/PreviewCard.tsx
@@ -1,22 +1,29 @@
 import React, { useState } from 'react';
+import * as UI from '@/styles/ui';
 
 export default function PreviewCard({ text }: { text: string }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="border rounded-lg p-4 bg-white shadow-sm" aria-label="Notice preview">
-      <div className="flex items-center justify-between mb-2">
+    <div aria-label="Notice preview">
+      <div className="mb-2 flex items-center justify-between">
         <h3 className="font-medium">Preview</h3>
-        <button type="button" className="text-sm underline" onClick={() => setOpen(true)}>Expand</button>
+        <button type="button" className="text-sm underline" onClick={() => setOpen(true)}>
+          Expand
+        </button>
       </div>
-      <p className="text-sm whitespace-pre-wrap max-h-40 overflow-auto" id="notice-preview">{text}</p>
+      <div className={UI.prose + ' whitespace-pre-wrap min-h-[420px]'} id="notice-preview">
+        {text}
+      </div>
       {open && (
-        <div role="dialog" aria-modal="true" className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white max-w-2xl w-full p-6 rounded-lg shadow-lg">
-            <div className="flex justify-between items-center mb-4">
-              <h4 className="font-medium">Notice preview</h4>
-              <button onClick={() => setOpen(false)} aria-label="Close" className="text-sm underline">Close</button>
+        <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white max-w-3xl w-full h-full md:h-auto md:max-h-[90vh] p-6 rounded-2xl shadow-card overflow-auto">
+            <div className="mb-4 flex items-center justify-between">
+              <h4 className={UI.h2}>Notice preview</h4>
+              <button onClick={() => setOpen(false)} aria-label="Close" className={UI.ghostPill}>
+                Close
+              </button>
             </div>
-            <div className="overflow-auto max-h-[70vh] whitespace-pre-wrap">{text}</div>
+            <div className={UI.prose + ' whitespace-pre-wrap'}>{text}</div>
           </div>
         </div>
       )}

--- a/src/components/publish/TrafficForm.tsx
+++ b/src/components/publish/TrafficForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ErrorSummary, { type ErrorItem } from '@/components/publish/ErrorSummary';
 import { listAuthorityPacks, type AuthorityPack } from '@/lib/authorityPacks';
+import * as UI from '@/styles/ui';
 
 interface FormData {
   title: string;
@@ -16,8 +17,6 @@ interface Props {
   autoFocusRef: React.RefObject<HTMLInputElement>;
   onAuthorityChange?: (pack: AuthorityPack | null) => void;
 }
-
-const inputClass = 'h-10 px-3 rounded-lg border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-600';
 
 export default function TrafficForm({ onSubmit, saving, autoFocusRef, onAuthorityChange }: Props) {
   const [form, setForm] = useState<FormData>({
@@ -76,20 +75,20 @@ export default function TrafficForm({ onSubmit, saving, autoFocusRef, onAuthorit
     <form onSubmit={submit} className="space-y-6" aria-describedby="traffic-desc">
       <ErrorSummary errors={errors} />
 
-      <div className="rounded-2xl border p-4 space-y-4">
-        <h2 className="text-lg font-medium">Applicant & Council</h2>
+      <section className={UI.section}>
+        <div className={UI.h2}>Applicant & Council</div>
         <div className="grid grid-cols-2 gap-4">
           <div className="col-span-2">
-            <label htmlFor="applicantEmail" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="applicantEmail" className={UI.label}>
               Applicant email
             </label>
-            <input id="applicantEmail" ref={autoFocusRef} type="email" value={form.applicantEmail} onChange={(e) => setField('applicantEmail', e.target.value)} className={inputClass + ' w-full'} />
+            <input id="applicantEmail" ref={autoFocusRef} type="email" value={form.applicantEmail} onChange={(e) => setField('applicantEmail', e.target.value)} className={UI.input + ' w-full'} />
           </div>
           <div>
-            <label htmlFor="council" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="council" className={UI.label}>
               Council
             </label>
-            <select id="council" value={form.councilPack} onChange={(e) => selectPack(e.target.value)} className={inputClass}>
+            <select id="council" value={form.councilPack} onChange={(e) => selectPack(e.target.value)} className={UI.input}>
               <option value="">Select council</option>
               {packs.map((p) => (
                 <option key={p.id} value={p.id}>
@@ -99,7 +98,7 @@ export default function TrafficForm({ onSubmit, saving, autoFocusRef, onAuthorit
             </select>
           </div>
           <div>
-            <label htmlFor="councilEmail" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="councilEmail" className={UI.label}>
               Council email
             </label>
             <input
@@ -107,7 +106,7 @@ export default function TrafficForm({ onSubmit, saving, autoFocusRef, onAuthorit
               type="email"
               value={form.councilEmail}
               onChange={(e) => setField('councilEmail', e.target.value)}
-              className={inputClass}
+              className={UI.input}
             />
             {pack && (
               <p className="mt-1 text-xs text-slate-500">
@@ -117,27 +116,27 @@ export default function TrafficForm({ onSubmit, saving, autoFocusRef, onAuthorit
             )}
           </div>
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-2xl border p-4 space-y-4">
-        <h2 className="text-lg font-medium">Application basics</h2>
+      <section className={UI.section}>
+        <div className={UI.h2}>Application basics</div>
         <div className="grid grid-cols-2 gap-4">
           <div className="col-span-2">
-            <label htmlFor="title" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="title" className={UI.label}>
               Title
             </label>
-            <input id="title" value={form.title} onChange={(e) => setField('title', e.target.value)} className={inputClass + ' w-full'} />
+            <input id="title" value={form.title} onChange={(e) => setField('title', e.target.value)} className={UI.input + ' w-full'} />
           </div>
           <div className="col-span-2">
-            <label htmlFor="description" className="block text-sm font-medium text-slate-700">
+            <label htmlFor="description" className={UI.label}>
               Description
             </label>
-            <textarea id="description" value={form.description} onChange={(e) => setField('description', e.target.value)} className="h-20 px-3 rounded-lg border border-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-600 w-full" />
+            <textarea id="description" value={form.description} onChange={(e) => setField('description', e.target.value)} className={UI.input + ' h-20 w-full'} />
           </div>
         </div>
-      </div>
+      </section>
 
-      <button type="submit" disabled={saving} className="h-10 px-4 rounded-lg bg-blue-600 text-white disabled:opacity-50">
+      <button type="submit" disabled={saving} className={UI.pillBtn}>
         {saving ? 'Saving…' : 'Submit'}
       </button>
     </form>

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -14,6 +14,7 @@ import { renderTrafficOrder } from '../../../templates/traffic-order.template';
 import { validatePremisesLicence } from '../../../schemas/rules/premises-licence.rules';
 import { validateGVOL } from '../../../schemas/rules/gvol.rules';
 import { validateTrafficOrder } from '../../../schemas/rules/traffic-order.rules';
+import * as UI from '@/styles/ui';
 
 export default function PublishPage() {
   const [noticeType, setNoticeType] = useState<NoticeType>('premises');
@@ -92,26 +93,52 @@ export default function PublishPage() {
   };
 
   return (
-    <div className="grid grid-cols-[minmax(0,720px),340px] gap-8" data-testid="publish-layout">
-      <main className="space-y-6">
-        <ErrorSummary errors={issues} />
-        <NoticeTypeSelect value={noticeType} onChange={setNoticeType} />
-        {noticeType === 'premises' && (
-          <PremisesForm onSubmit={handlePremisesSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
-        )}
-        {noticeType === 'gvol' && (
-          <GVOLForm onSubmit={handleGVOLSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
-        )}
-        {noticeType === 'traffic' && (
-          <TrafficForm onSubmit={handleTrafficSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
-        )}
-      </main>
-      <aside className="sticky top-6 w-[340px] space-y-4">
-        <PreviewCard text={preview} />
-        <ComplianceCard issues={issues} />
-        <KeyDatesCard representationDeadline={representationDeadline} consultationDays={consultationDays} />
-        <CostCard cost={cost} />
-      </aside>
+    <div className={UI.gradientBg}>
+      <div className={UI.container + ' py-8 md:py-10'}>
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className={UI.h2}>Publish a notice</h1>
+          <div className="hidden md:flex items-center gap-2 text-sm">
+            <span className={UI.ghostPill}>Upload Blue Notice</span>
+            <span className="text-slate-400">/</span>
+            <span className={UI.ghostPill}>Build from Template</span>
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-3 gap-8" data-testid="publish-layout">
+          <main className="md:col-span-2 space-y-6">
+            <ErrorSummary errors={issues} />
+            <section className={UI.section}>
+              <label htmlFor="notice-type" className={UI.label + ' mb-2'}>
+                What type of notice do you require?
+              </label>
+              <NoticeTypeSelect value={noticeType} onChange={setNoticeType} />
+            </section>
+            {noticeType === 'premises' && (
+              <PremisesForm onSubmit={handlePremisesSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
+            )}
+            {noticeType === 'gvol' && (
+              <GVOLForm onSubmit={handleGVOLSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
+            )}
+            {noticeType === 'traffic' && (
+              <TrafficForm onSubmit={handleTrafficSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
+            )}
+          </main>
+          <aside className="md:col-span-1 space-y-4">
+            <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
+              <PreviewCard text={preview} />
+            </div>
+            <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
+              <ComplianceCard issues={issues} />
+            </div>
+            <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
+              <KeyDatesCard representationDeadline={representationDeadline} consultationDays={consultationDays} />
+            </div>
+            <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
+              <CostCard cost={cost} />
+            </div>
+          </aside>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/styles/ui.ts
+++ b/src/styles/ui.ts
@@ -1,0 +1,12 @@
+export const container = "mx-auto w-full max-w-[1200px] px-4 md:px-6 lg:px-10";
+export const gradientBg = "min-h-screen bg-[radial-gradient(1000px_600px_at_30%_-10%,#e6efff_0%,transparent_50%),linear-gradient(180deg,#f7f9ff_0%,#eef3ff_40%,#f9fbff_100%)]";
+export const card = "rounded-2xl bg-white border border-slate-200 shadow-[0_8px_28px_rgba(2,8,23,.08),0_2px_6px_rgba(2,8,23,.05)]";
+export const railCard = card + " p-4";
+export const section = card + " p-5 md:p-6 space-y-4";
+export const h1 = "font-display text-4xl md:text-5xl font-extrabold tracking-tight";
+export const h2 = "font-display text-xl md:text-2xl font-semibold";
+export const label = "text-sm font-medium text-slate-800";
+export const input = "h-11 rounded-lg border border-slate-300 bg-white px-3 text-[15px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
+export const pillBtn = "inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium bg-blue-600 text-white hover:bg-blue-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-50";
+export const ghostPill = "inline-flex items-center gap-2 rounded-full px-3 py-1.5 border border-slate-300 bg-white hover:border-blue-400 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
+export const prose = "prose max-w-none text-[14px] leading-6 prose-headings:mt-0";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,26 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  safelist: ['min-h-[420px]'],
   theme: {
     extend: {
-      fontFamily: { sans: ['Inter', 'ui-sans-serif', 'system-ui'] },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+        display: ['Inter', 'ui-sans-serif', 'system-ui'],
+        body: ['Inter', 'ui-sans-serif', 'system-ui'],
+      },
+      colors: {
+        brand: {
+          50: '#f3f7ff',
+          100: '#e6efff',
+          200: '#cddfff',
+          400: '#6ea8ff',
+          600: '#2563eb',
+          700: '#1e40af',
+        },
+      },
+      borderRadius: { pill: '999px', '2xl': '24px' },
+      boxShadow: { card: '0 8px 28px rgba(2,8,23,.08), 0 2px 6px rgba(2,8,23,.05)' },
       keyframes: {
         progress: {
           '0%': { backgroundPosition: '0% 0%' },


### PR DESCRIPTION
## Summary
- add reusable UI design tokens and Tailwind theme extensions
- theme /publish with gradient layout, card sections, and updated right rail
- restyle forms, activities grid, preview, and error summary with accessible pill buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c299d802ac8330a878a19f0521b07e