### PR TITLE
Align publish page styling with home

### DIFF
--- a/src/components/AsyncCombobox.tsx
+++ b/src/components/AsyncCombobox.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
+import * as UI from '@/styles/ui';
 
 function debounce<F extends (...args: any[]) => void>(fn: F, wait: number) {
   let t: any;
@@ -77,7 +78,7 @@ export default function AsyncCombobox<T>(props: AsyncComboboxProps<T>) {
 
   return (
     <div className="w-full">
-      <label className="block text-sm font-medium mb-1">
+      <label className={UI.label + ' mb-1'}>
         {label}
         {required && <span className="text-rose-600 ml-0.5">*</span>}
       </label>
@@ -86,7 +87,7 @@ export default function AsyncCombobox<T>(props: AsyncComboboxProps<T>) {
         aria-expanded={open}
         aria-autocomplete="list"
         data-testid={inputTestId}
-        className="w-full border rounded p-2"
+        className={UI.input + ' w-full'}
         placeholder={placeholder}
         value={query}
         onChange={handleChange}
@@ -100,14 +101,14 @@ export default function AsyncCombobox<T>(props: AsyncComboboxProps<T>) {
         <ul
           role="listbox"
           ref={listRef}
-          className="border mt-1 rounded bg-white shadow max-h-60 overflow-auto"
+          className="border border-slate-200 mt-1 rounded-lg bg-white shadow-card max-h-60 overflow-auto"
         >
           {options.map((opt, idx) => (
             <li
               key={getKey(opt)}
               role="option"
               aria-selected={idx === highlight}
-              className={`px-3 py-2 cursor-pointer ${idx === highlight ? "bg-slate-100" : ""}`}
+              className={`px-3 py-2 cursor-pointer ${idx === highlight ? 'bg-slate-100' : ''}`}
               onMouseDown={(e) => {
                 e.preventDefault();
                 handleSelect(opt);

--- a/src/components/publish/ErrorSummary.tsx
+++ b/src/components/publish/ErrorSummary.tsx
@@ -11,7 +11,7 @@ export default function ErrorSummary({ errors }: { errors: ErrorItem[] }) {
       role="alert"
       aria-labelledby="error-summary-title"
     >
-      <h2 id="error-summary-title" className="mb-2 font-semibold">
+      <h2 id="error-summary-title" className="mb-2 font-bold text-red-900">
         There is a problem
       </h2>
       <ul className="list-disc pl-5 text-sm space-y-1">

--- a/src/components/publish/GVOLForm.tsx
+++ b/src/components/publish/GVOLForm.tsx
@@ -75,7 +75,7 @@ export default function GVOLForm({ onSubmit, saving, autoFocusRef, onAuthorityCh
   const packs = listAuthorityPacks();
 
   return (
-    <form onSubmit={submit} className="space-y-6" aria-describedby="gvol-desc">
+    <form onSubmit={submit} className="space-y-8" aria-describedby="gvol-desc">
       <ErrorSummary errors={errors} />
 
       <section className={UI.section}>

--- a/src/components/publish/PremisesForm.tsx
+++ b/src/components/publish/PremisesForm.tsx
@@ -87,7 +87,7 @@ export default function PremisesForm({ onSubmit, saving, autoFocusRef, onAuthori
   const packs = listAuthorityPacks();
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form onSubmit={handleSubmit} className="space-y-8">
       <ErrorSummary errors={errors} />
 
       <section className={UI.section}>

--- a/src/components/publish/RightRail/PreviewCard.tsx
+++ b/src/components/publish/RightRail/PreviewCard.tsx
@@ -11,19 +11,19 @@ export default function PreviewCard({ text }: { text: string }) {
           Expand
         </button>
       </div>
-      <div className={UI.prose + ' whitespace-pre-wrap min-h-[420px]'} id="notice-preview">
+      <div className={`${UI.prose} whitespace-pre-wrap min-h-[420px]`} id="notice-preview">
         {text}
       </div>
       {open && (
         <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white max-w-3xl w-full h-full md:h-auto md:max-h-[90vh] p-6 rounded-2xl shadow-card overflow-auto">
+          <div className={UI.card + ' max-w-3xl w-full h-full md:h-auto md:max-h-[90vh] p-6 md:p-8 overflow-auto'}>
             <div className="mb-4 flex items-center justify-between">
               <h4 className={UI.h2}>Notice preview</h4>
               <button onClick={() => setOpen(false)} aria-label="Close" className={UI.ghostPill}>
                 Close
               </button>
             </div>
-            <div className={UI.prose + ' whitespace-pre-wrap'}>{text}</div>
+            <div className={`${UI.prose} whitespace-pre-wrap text-base md:text-lg`}>{text}</div>
           </div>
         </div>
       )}

--- a/src/components/publish/TrafficForm.tsx
+++ b/src/components/publish/TrafficForm.tsx
@@ -72,7 +72,7 @@ export default function TrafficForm({ onSubmit, saving, autoFocusRef, onAuthorit
   const packs = listAuthorityPacks();
 
   return (
-    <form onSubmit={submit} className="space-y-6" aria-describedby="traffic-desc">
+    <form onSubmit={submit} className="space-y-8" aria-describedby="traffic-desc">
       <ErrorSummary errors={errors} />
 
       <section className={UI.section}>

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -94,9 +94,9 @@ export default function PublishPage() {
 
   return (
     <div className={UI.gradientBg}>
-      <div className={UI.container + ' py-8 md:py-10'}>
-        <div className="mb-6 flex items-center justify-between">
-          <h1 className={UI.h2}>Publish a notice</h1>
+      <div className={UI.container + ' py-12'}>
+        <div className="mb-8 flex items-center justify-between">
+          <h1 className={UI.h1}>Publish a notice</h1>
           <div className="hidden md:flex items-center gap-2 text-sm">
             <span className={UI.ghostPill}>Upload Blue Notice</span>
             <span className="text-slate-400">/</span>
@@ -104,8 +104,8 @@ export default function PublishPage() {
           </div>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-8" data-testid="publish-layout">
-          <main className="md:col-span-2 space-y-6">
+        <div className="grid md:grid-cols-3 gap-10" data-testid="publish-layout">
+          <main className="md:col-span-2 space-y-8">
             <ErrorSummary errors={issues} />
             <section className={UI.section}>
               <label htmlFor="notice-type" className={UI.label + ' mb-2'}>
@@ -123,7 +123,7 @@ export default function PublishPage() {
               <TrafficForm onSubmit={handleTrafficSubmit} saving={false} autoFocusRef={autoFocusRef} onAuthorityChange={handleAuthorityChange} />
             )}
           </main>
-          <aside className="md:col-span-1 space-y-4">
+          <aside className="md:col-span-1 space-y-6">
             <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
               <PreviewCard text={preview} />
             </div>
@@ -131,7 +131,10 @@ export default function PublishPage() {
               <ComplianceCard issues={issues} />
             </div>
             <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
-              <KeyDatesCard representationDeadline={representationDeadline} consultationDays={consultationDays} />
+              <KeyDatesCard
+                representationDeadline={representationDeadline}
+                consultationDays={consultationDays}
+              />
             </div>
             <div className={UI.railCard + ' hover:shadow-[0_10px_34px_rgba(2,8,23,.10)]'}>
               <CostCard cost={cost} />

--- a/src/styles/ui.ts
+++ b/src/styles/ui.ts
@@ -1,12 +1,18 @@
 export const container = "mx-auto w-full max-w-[1200px] px-4 md:px-6 lg:px-10";
-export const gradientBg = "min-h-screen bg-[radial-gradient(1000px_600px_at_30%_-10%,#e6efff_0%,transparent_50%),linear-gradient(180deg,#f7f9ff_0%,#eef3ff_40%,#f9fbff_100%)]";
-export const card = "rounded-2xl bg-white border border-slate-200 shadow-[0_8px_28px_rgba(2,8,23,.08),0_2px_6px_rgba(2,8,23,.05)]";
-export const railCard = card + " p-4";
-export const section = card + " p-5 md:p-6 space-y-4";
+export const gradientBg =
+  "min-h-screen bg-[radial-gradient(1000px_600px_at_30%_-10%,#c7d2ff_0%,transparent_60%),linear-gradient(180deg,#eff6ff_0%,#f3e8ff_45%,#fff_100%)]";
+export const card =
+  "rounded-2xl bg-white border border-slate-200 shadow-[0_8px_28px_rgba(2,8,23,.08),0_2px_6px_rgba(2,8,23,.05)]";
+export const railCard = card + " p-5";
+export const section = card + " p-6 md:p-8 space-y-6";
 export const h1 = "font-display text-4xl md:text-5xl font-extrabold tracking-tight";
 export const h2 = "font-display text-xl md:text-2xl font-semibold";
 export const label = "text-sm font-medium text-slate-800";
-export const input = "h-11 rounded-lg border border-slate-300 bg-white px-3 text-[15px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
-export const pillBtn = "inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium bg-blue-600 text-white hover:bg-blue-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-50";
-export const ghostPill = "inline-flex items-center gap-2 rounded-full px-3 py-1.5 border border-slate-300 bg-white hover:border-blue-400 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
-export const prose = "prose max-w-none text-[14px] leading-6 prose-headings:mt-0";
+export const input =
+  "h-11 rounded-lg border border-slate-300 bg-white px-3 text-[15px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
+export const pillBtn =
+  "inline-flex items-center gap-2 rounded-full px-5 py-2.5 font-semibold bg-blue-600 text-white hover:bg-blue-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:opacity-50";
+export const ghostPill =
+  "inline-flex items-center gap-2 rounded-full px-3 py-1.5 border border-slate-300 bg-white hover:border-blue-400 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-white";
+export const prose =
+  "prose max-w-none text-[14px] leading-6 prose-headings:mt-0";


### PR DESCRIPTION
## Summary
- add shared design tokens for gradient backgrounds, cards, buttons and form controls
- restyle publish flow and supporting components to use product cards, pill buttons and prose previews
- refresh error summary and autocomplete to match home page aesthetics

## Testing
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npm test` *(fails: An update to AsyncCombobox inside a test was not wrapped in act(...))*


------
https://chatgpt.com/codex/tasks/task_e_68c2a381268c8330a4cd3b893ca3dde0