### PR TITLE
feat: finalize notice upload flow

### DIFF
--- a/server/__tests__/upload.test.ts
+++ b/server/__tests__/upload.test.ts
@@ -33,4 +33,18 @@ describe('upload handler (unit)', () => {
     expect(result.text).toBe('');
     expect(result.error).toBe('OCR_EMPTY');
   });
+
+  it('detects duplicate uploads via sha256', async () => {
+    const file = {
+      originalname: 'dup.pdf',
+      buffer: Buffer.from('same'),
+      mimetype: 'application/pdf',
+      size: 4,
+    } as any;
+    const first = await handleUploadCore(file, {}, {}, {} as any);
+    expect(first.ok).toBe(true);
+    const second = await handleUploadCore(file, {}, {}, {} as any);
+    expect(second.ok).toBe(false);
+    expect((second as any).error.code).toBe('DUPLICATE');
+  });
 });

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import multer from "multer";
 import { createClient } from "@supabase/supabase-js";
-import { extname } from "node:path";
+import { createHash } from "node:crypto";
 import slugify from "slugify";
 import { extractTextFromBuffer } from "../utils/extractText";
 
@@ -28,6 +28,8 @@ const upload = (multer as any)({
 });
 
 const router = Router();
+const PAGE_LIMIT = Number(process.env.PAGE_LIMIT || 4);
+const seenHashes = new Map<string, string>();
 
 // Simple in-memory rate limiter: 20/min per IP
 const hits = new Map<string, { count: number; reset: number }>();
@@ -68,6 +70,7 @@ export async function handleUploadCore(
   const skipOcr = String(query.skipOcr) === "1";
   let ocr_text = "";
   let meta: any = {};
+  const sha256 = createHash("sha256").update(file.buffer).digest("hex");
 
   if (!skipOcr) {
     try {
@@ -95,6 +98,41 @@ export async function handleUploadCore(
     }
   }
 
+  const pageCount = meta.pages || meta.pageCount || 0;
+  const mimeMeta = {
+    engine: meta.engine || (hasSupabase ? "supabase" : "local"),
+    pageCount,
+    bytes: file.size,
+    mime: file.mimetype,
+    sha256,
+    stored: false,
+  } as any;
+
+  if (pageCount > PAGE_LIMIT) {
+    return {
+      ok: false,
+      error: {
+        code: "TOO_MANY_PAGES",
+        message: `File has ${pageCount} pages; limit is ${PAGE_LIMIT}.`,
+      },
+      meta: mimeMeta,
+    };
+  }
+
+  if (seenHashes.has(sha256)) {
+    return {
+      ok: false,
+      error: {
+        code: "DUPLICATE",
+        message: "Duplicate notice uploaded",
+        existing: seenHashes.get(sha256),
+      },
+      meta: mimeMeta,
+    };
+  }
+
+  seenHashes.set(sha256, path);
+
   if (!hasSupabase) {
     if (!ocr_text.trim()) {
       return {
@@ -102,14 +140,14 @@ export async function handleUploadCore(
         text: "",
         ocr_text: "",
         error: "OCR_EMPTY",
-        meta: { engine: meta.engine || "local", pages: meta.pages, bytes: file.size, stored: false },
+        meta: mimeMeta,
       };
     }
     return {
       ok: true,
       text: ocr_text,
       ocr_text,
-      meta: { engine: meta.engine || "local", pages: meta.pages, bytes: file.size, stored: false },
+      meta: mimeMeta,
     };
   }
 
@@ -159,7 +197,7 @@ export async function handleUploadCore(
     ocr_text,
     text: ocr_text,
     ...(ocr_text.trim() ? {} : { error: "OCR_EMPTY" }),
-    meta: { engine: meta.engine || "supabase", pages: meta.pages, bytes: file.size, stored: true },
+    meta: { ...mimeMeta, stored: true },
   };
 }
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import SiteHeader from '../SiteHeader';
+
+export default function Header() {
+  return <SiteHeader />;
+}

--- a/src/components/publish/Checklist.focus.test.tsx
+++ b/src/components/publish/Checklist.focus.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import Checklist, { ChecklistItem } from './Checklist';
+
+describe('Checklist focus', () => {
+  it('focuses target input when Fix this clicked', async () => {
+    const items: ChecklistItem[] = [{ id: 'a', label: 'Applicant name present', ok: false, target: 'applicantName' }];
+    render(
+      <div>
+        <input id="applicantName" />
+        <Checklist items={items} />
+      </div>
+    );
+    await userEvent.click(screen.getByText('Fix this'));
+    const input = document.getElementById('applicantName');
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/src/components/publish/ProgressBar.tsx
+++ b/src/components/publish/ProgressBar.tsx
@@ -9,7 +9,7 @@ export default function ProgressBar({ step }: { step: 1 | 2 | 3 }) {
         <span>Confirm your Notice</span>
         <span>Pay</span>
       </div>
-      <div className="h-1 bg-slate-200">
+      <div className="h-1 bg-white/40">
         <div className="h-1 bg-brand-blue" style={{ width: percent }} />
       </div>
     </div>

--- a/src/components/publish/RightRail/ComplianceCard.tsx
+++ b/src/components/publish/RightRail/ComplianceCard.tsx
@@ -1,5 +1,5 @@
 import Checklist, { type ChecklistItem } from '../ComplianceChecklist';
 
-export default function ComplianceCard({ items }: { items: ChecklistItem[] }) {
-  return <Checklist items={items} />;
+export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[]; onFix?: (target?: string) => void }) {
+  return <Checklist items={items} onFix={onFix} />;
 }

--- a/src/components/publish/UploadNoticeFlow.test.tsx
+++ b/src/components/publish/UploadNoticeFlow.test.tsx
@@ -28,8 +28,8 @@ describe('UploadNoticeFlow gating', () => {
     await waitFor(() => screen.getByText('1 High St'));
     await userEvent.click(screen.getByText('1 High St'));
     await userEvent.type(screen.getByLabelText(/Date of submission/i), '2024-01-01');
-    await userEvent.click(screen.getByLabelText(/notice text is accurate/i));
-    await userEvent.click(screen.getByLabelText(/authority to publish/i));
+    await userEvent.click(screen.getByLabelText(/true and accurate copy/i));
+    await userEvent.click(screen.getByLabelText(/false information is an offence/i));
 
     await waitFor(() => expect(payBtn).toBeEnabled());
   });

--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -10,6 +10,7 @@ import { lookupCouncilByPostcode } from '@/lib/councilLookup';
 import { runMandatoryChecks, calcRepsDeadline } from '@/lib/licensing/checks';
 import * as UI from '@/styles/ui';
 import type { NoticeDraft } from '@/types/notice';
+import { sha256Hex } from '@/lib/hash';
 
 export default function UploadNoticeFlow() {
   const [step, setStep] = useState<1 | 2 | 3>(1);
@@ -32,6 +33,8 @@ export default function UploadNoticeFlow() {
   const [confirmA, setConfirmA] = useState(false);
   const [confirmB, setConfirmB] = useState(false);
   const lookedUpEmail = React.useRef('');
+  const lookedUpName = React.useRef('');
+  const lookedUpAddress = React.useRef('');
   const requiredOk =
     draft.applicantName.trim() &&
     draft.premisesAddress.trim() &&
@@ -59,11 +62,24 @@ export default function UploadNoticeFlow() {
             <div className="space-y-6">
               <section className={UI.section}>
                 <div>
+                  <label htmlFor="noticeText" className={UI.label}>Notice text</label>
+                  <textarea
+                    id="noticeText"
+                    className={UI.input + ' h-40'}
+                    value={text}
+                    onChange={(e) => {
+                      setText(e.target.value);
+                      setDraft((d) => ({ ...d, finalText: e.target.value }));
+                    }}
+                  />
+                </div>
+                <div className="mt-4">
                   <label htmlFor="applicantName" className={UI.label}>
                     Applicant name<span className="text-rose-600">*</span>
                   </label>
                   <input
                     id="applicantName"
+                    required
                     className={UI.input}
                     value={draft.applicantName}
                     onChange={(e) => setDraft({ ...draft, applicantName: e.target.value })}
@@ -79,6 +95,8 @@ export default function UploadNoticeFlow() {
                       const res = lookupCouncilByPostcode(pc);
                       if (res) {
                         lookedUpEmail.current = res.councilEmail;
+                        lookedUpName.current = res.councilName;
+                        lookedUpAddress.current = res.councilAddress;
                         setDraft((d) => ({
                           ...d,
                           councilName: res.councilName,
@@ -95,10 +113,14 @@ export default function UploadNoticeFlow() {
                   </label>
                   <input
                     id="councilName"
+                    required
                     className={UI.input}
                     value={draft.councilName}
                     onChange={(e) => setDraft({ ...draft, councilName: e.target.value })}
                   />
+                  {lookedUpName.current && draft.councilName !== lookedUpName.current && (
+                    <p className="mt-1 text-xs text-amber-700">Value differs from council directory</p>
+                  )}
                 </div>
                 <div className="mt-4">
                   <label htmlFor="councilEmail" className={UI.label}>
@@ -106,12 +128,13 @@ export default function UploadNoticeFlow() {
                   </label>
                   <input
                     id="councilEmail"
+                    required
                     className={UI.input}
                     value={draft.councilEmail}
                     onChange={(e) => setDraft({ ...draft, councilEmail: e.target.value })}
                   />
                   {lookedUpEmail.current && draft.councilEmail !== lookedUpEmail.current && (
-                    <p className="mt-1 text-xs text-amber-700">Email differs from council directory</p>
+                    <p className="mt-1 text-xs text-amber-700">Value differs from council directory</p>
                   )}
                 </div>
                 <div className="mt-4">
@@ -120,10 +143,14 @@ export default function UploadNoticeFlow() {
                   </label>
                   <input
                     id="councilAddress"
+                    required
                     className={UI.input}
                     value={draft.councilAddress}
                     onChange={(e) => setDraft({ ...draft, councilAddress: e.target.value })}
                   />
+                  {lookedUpAddress.current && draft.councilAddress !== lookedUpAddress.current && (
+                    <p className="mt-1 text-xs text-amber-700">Value differs from council directory</p>
+                  )}
                 </div>
                 <div className="mt-4">
                   <label htmlFor="applicationDate" className={UI.label}>
@@ -131,6 +158,7 @@ export default function UploadNoticeFlow() {
                   </label>
                   <input
                     id="applicationDate"
+                    required
                     type="date"
                     className={UI.input}
                     value={draft.applicationDate}
@@ -148,7 +176,7 @@ export default function UploadNoticeFlow() {
                     onChange={(e) => setConfirmA(e.target.checked)}
                   />
                   <label htmlFor="confirm-a" className="text-sm">
-                    I confirm the notice text is accurate
+                    I confirm the above text is a true and accurate copy of the notice published/displayed.
                   </label>
                 </div>
                 <div className="flex items-center gap-2">
@@ -159,7 +187,7 @@ export default function UploadNoticeFlow() {
                     onChange={(e) => setConfirmB(e.target.checked)}
                   />
                   <label htmlFor="confirm-b" className="text-sm">
-                    I confirm I have authority to publish
+                    I understand that supplying false information is an offence.
                   </label>
                 </div>
                 <div className="mt-4 flex gap-2">
@@ -172,7 +200,11 @@ export default function UploadNoticeFlow() {
                   <button
                     className="rounded-md border px-4 py-2"
                     disabled={!canContinue}
-                    onClick={() => setStep(3)}
+                    onClick={async () => {
+                      const hash = await sha256Hex((draft.originalFileMeta?.sha256 || '') + (draft.finalText || ''));
+                      setDraft((d) => ({ ...d, proofHash: hash }));
+                      setStep(3);
+                    }}
                   >
                     Continue to Pay
                   </button>

--- a/src/components/upload/FileDropOCR.tsx
+++ b/src/components/upload/FileDropOCR.tsx
@@ -13,6 +13,7 @@ export default function FileDropOCR({ onText, onMeta }: FileDropOCRProps) {
   const [localText, setLocalText] = useState('');
   const [lastFile, setLastFile] = useState<File | null>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const PAGE_LIMIT = Number((import.meta as any).env?.VITE_PAGE_LIMIT || 4);
 
   const pretty = (bytes: number) => bytes < 1024
     ? `${bytes} B`
@@ -33,6 +34,11 @@ export default function FileDropOCR({ onText, onMeta }: FileDropOCRProps) {
   const doUpload = async (file: File) => {
     const t0 = performance.now();
     setError('');
+    if (file.size > 25 * 1024 * 1024) {
+      setError('File is over 25MB.');
+      setState('error');
+      return;
+    }
     try {
       setState('uploading');
       const isTest = (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test')
@@ -52,8 +58,15 @@ export default function FileDropOCR({ onText, onMeta }: FileDropOCRProps) {
       fd.append('file', file);
       const res = await fetch('/api/upload', { method: 'POST', body: fd });
       setState('ocr');
-      if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
+      if (!res.ok || data?.ok === false) {
+        const msg = data?.error?.message || data?.error || 'Upload failed.';
+        setError(msg);
+        onMeta?.(data?.meta || {});
+        setState('error');
+        setElapsed(performance.now() - t0);
+        return;
+      }
       const text = data?.text || '';
       setLocalText(text);
       onText(text);
@@ -61,7 +74,12 @@ export default function FileDropOCR({ onText, onMeta }: FileDropOCRProps) {
       if (data?.error === 'OCR_EMPTY') {
         setError("We couldn't read this file. Build from details instead.");
       }
-      setState('ready');
+      if (data?.meta?.pageCount && data.meta.pageCount > PAGE_LIMIT) {
+        setError(`File has ${data.meta.pageCount} pages; limit is ${PAGE_LIMIT}.`);
+        setState('error');
+      } else {
+        setState('ready');
+      }
       setElapsed(performance.now() - t0);
     } catch (e) {
       setState('error');

--- a/src/lib/licensing/checks.test.ts
+++ b/src/lib/licensing/checks.test.ts
@@ -12,7 +12,7 @@ describe('runMandatoryChecks', () => {
   it('flags missing fields', () => {
     const draft: NoticeDraft = {} as any;
     const res = runMandatoryChecks(draft);
-    const applicant = res.find((r) => r.message.includes('Applicant name'));
+    const applicant = res.find((r) => r.label.includes('Applicant name'));
     expect(applicant?.ok).toBe(false);
   });
 });

--- a/src/lib/licensing/checks.ts
+++ b/src/lib/licensing/checks.ts
@@ -1,6 +1,13 @@
 import { NoticeDraft } from '@/types/notice';
 
-export type ComplianceItem = { ok: boolean; message: string };
+export type ComplianceItem = {
+  id: string;
+  label: string;
+  ok: boolean;
+  target?: string;
+  severity?: 'error' | 'warning';
+  rationale?: string;
+};
 export type ComplianceResult = ComplianceItem[];
 
 export function calcRepsDeadline(date: string): string {
@@ -11,20 +18,44 @@ export function calcRepsDeadline(date: string): string {
 
 export function runMandatoryChecks(draft: NoticeDraft): ComplianceResult {
   const items: ComplianceResult = [];
-  const push = (ok: boolean, message: string) => items.push({ ok, message });
+  const push = (
+    id: string,
+    ok: boolean,
+    label: string,
+    target?: string,
+    severity?: 'error' | 'warning'
+  ) => items.push({ id, ok, label, target, severity });
 
-  push(!!draft.applicantName, 'Applicant name present');
-  push(!!draft.premisesAddress, 'Premises full postal address present');
-  push(!!draft.councilName, 'Council name present');
-  push(!!draft.councilEmail, 'Council email present');
-  push(!!draft.councilAddress, 'Council address present');
-  push(!!draft.applicationDate, 'Application date present');
+  push('applicantName', !!draft.applicantName, 'Applicant name present', 'applicantName');
+  push('premisesAddress', !!draft.premisesAddress, 'Premises full postal address present', 'premises-address');
+  push('premisesName', !!draft.premisesName, 'Premises name present');
+  push('applicationType', !!draft.applicationType, 'Application type present');
+  push('activities', !!(draft.activities && draft.activities.length), 'Activities applied for present');
+  push('hours', !!draft.hours, 'Hours of operation present');
+  push('councilName', !!draft.councilName, 'Council name present', 'councilName');
+  push('councilEmail', !!draft.councilEmail, 'Council email present', 'councilEmail');
+  push('councilAddress', !!draft.councilAddress, 'Council address present', 'councilAddress');
+  push('applicationDate', !!draft.applicationDate, 'Application date present', 'applicationDate');
   if (draft.repsDeadline) {
     const expected = calcRepsDeadline(draft.applicationDate);
-    push(draft.repsDeadline === expected, `Representation deadline = application date + 28 days (${expected})`);
+    push(
+      'repsDeadline',
+      draft.repsDeadline === expected,
+      `Representation deadline = application date + 28 days (${expected})`,
+      'applicationDate'
+    );
   } else {
-    push(false, 'This notice does not state the representation deadline — please enter manually.');
+    push(
+      'repsDeadline',
+      false,
+      'This notice does not state the representation deadline — please enter manually.',
+      'applicationDate',
+      'warning'
+    );
   }
+  push('inspectionLocation', !!draft.inspectionLocation, 'Inspection location present');
+  push('repsMethod', !!draft.repsMethod, 'Representation method present');
+  push('statutoryWarning', !!draft.statutoryWarningPresent, 'Statutory warning line present');
 
   return items;
 }

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import * as UI from '@/styles/ui';
 import UploadNoticeFlow from '@/components/publish/UploadNoticeFlow';
 import TemplateBuilder from './publish';
-import SiteHeader from '@/components/SiteHeader';
+import Header from '@/components/layout/Header';
 
 export default function PublishPage() {
   const [tab, setTab] = useState<'notice' | 'template'>('notice');
@@ -22,7 +22,7 @@ export default function PublishPage() {
 
   return (
     <div className={UI.gradientBg} data-testid="publish-layout">
-      <SiteHeader />
+      <Header />
       <main className={UI.container + ' py-6'}>
         <h1 className={UI.h1 + ' mb-6'}>Publish a notice</h1>
         <nav role="tablist" className="mb-4 flex gap-2">

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -40,7 +40,13 @@ export type NoticeDraft = {
   inspectionLocation?: string;
   repsMethod?: string;
   statutoryWarningPresent?: boolean;
-  originalFileMeta?: any;
+  originalFileMeta?: {
+    mime: string;
+    pageCount: number;
+    bytes: number;
+    sha256: string;
+    [k: string]: unknown;
+  };
   finalText?: string;
   proofHash?: string;
 };


### PR DESCRIPTION
## Summary
- add SHA-256 duplicate detection and page-limit enforcement to notice uploads
- expose editable OCR text with confirmation gating and proof hash
- expand licensing checks and polish progress bar contrast

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e67bfa208330a9c52d270b438af9