### PR TITLE
Polish publish page layout and right-rail cards

### DIFF
--- a/src/components/publish/ProgressBar.tsx
+++ b/src/components/publish/ProgressBar.tsx
@@ -17,7 +17,7 @@ export default function ProgressBar({ step, totalSteps = 3, labels }: Props) {
           const state = idx < step ? 'completed' : idx === step ? 'current' : 'upcoming';
           const active = state === 'current';
           return (
-            <div key={i} className="flex items-center gap-2">
+            <div key={i} className="flex items-center gap-x-3 md:gap-x-4">
               <div className={`${UI.stepDotBase} ${active ? UI.stepDotActive : ''}`} aria-current={active} aria-label={`Step ${idx}`} />
               <span
                 className={`text-sm ${active ? 'text-white/90 font-medium' : 'text-white/90'}`}

--- a/src/components/publish/RightRail/ComplianceCard.tsx
+++ b/src/components/publish/RightRail/ComplianceCard.tsx
@@ -10,36 +10,80 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
     if (onFix) onFix(target);
   };
 
+  const groupForLabel = (label: string) => {
+    const lower = label.toLowerCase();
+    if (lower.includes('applicant')) return 'Applicant';
+    if (lower.includes('council')) return 'Council';
+    if (lower.includes('date') || lower.includes('deadline')) return 'Dates';
+    return 'Other';
+  };
+
+  const grouped = items.reduce<Record<string, ChecklistItem[]>>((acc, item) => {
+    const key = groupForLabel(item.label);
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+
+  const orderedGroups = [
+    { key: 'Applicant', label: 'Applicant' },
+    { key: 'Council', label: 'Council' },
+    { key: 'Dates', label: 'Dates' },
+    { key: 'Other', label: 'Other checks' },
+  ].filter((group) => grouped[group.key]?.length);
+
   return (
     <div className={`${UI.card} ${UI.cardHover} p-4 md:p-5`} aria-label="Compliance checklist">
       <h3 className="text-sm font-semibold text-blue-900 mb-2">Compliance checklist</h3>
-      <p className="sr-only" aria-live="polite">{unresolved.length} issues remaining</p>
-      <div className="space-y-2.5">
+      <p className="sr-only" role="status" aria-live="polite">
+        {unresolved.length} issues remaining
+      </p>
+      <div className="space-y-4">
         {allGood ? (
           <div className="flex items-center gap-2 text-green-700 text-sm">
             <span aria-hidden className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-green-600 text-white text-[10px]">✔</span>
             All checks passed — ready to publish
           </div>
         ) : (
-          <ul>
-            {items.map((item) => (
-              <li key={item.id} className="grid grid-cols-[1fr_auto] items-start gap-3 py-1.5">
-                <span className={`text-[13px] ${item.ok ? 'text-green-700' : 'text-slate-700'}`}>{item.label}</span>
-                {!item.ok ? (
-                  <button
-                    type="button"
-                    className="text-xs px-2 h-7 rounded-md ring-1 ring-blue-200/70 bg-white hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white"
-                    onClick={() => handleFix(item.target)}
-                    data-field={item.id}
-                  >
-                    Fix this
-                  </button>
-                ) : (
-                  <span aria-hidden className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-600 text-white text-[10px]">✔</span>
-                )}
-              </li>
+          <div className="space-y-3">
+            {orderedGroups.map((group, idx) => (
+              <div key={group.key} className={idx === 0 ? '' : 'pt-1'}>
+                <h4
+                  className={`text-[11px] font-semibold uppercase tracking-wide text-slate-600 ${idx === 0 ? 'mt-0' : 'mt-2'} mb-1`}
+                >
+                  {group.label}
+                </h4>
+                <div className="grid grid-cols-[1fr_auto] items-start gap-x-3 gap-y-2">
+                  {grouped[group.key]?.map((item) => (
+                    <React.Fragment key={item.id}>
+                      <span
+                        className={`text-[13px] leading-5 ${item.ok ? 'text-green-700' : 'text-slate-700'}`}
+                      >
+                        {item.label}
+                      </span>
+                      {item.ok ? (
+                        <span
+                          aria-hidden
+                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-600 text-white text-[10px]"
+                        >
+                          ✔
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          className="inline-flex h-8 items-center justify-center rounded-md border border-blue-200/70 bg-white px-3 text-xs font-medium text-blue-700 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white"
+                          onClick={() => handleFix(item.target)}
+                          data-field={item.id}
+                        >
+                          Fix this
+                        </button>
+                      )}
+                    </React.Fragment>
+                  ))}
+                </div>
+              </div>
             ))}
-          </ul>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/publish/RightRail/KeyDatesCard.tsx
+++ b/src/components/publish/RightRail/KeyDatesCard.tsx
@@ -1,28 +1,40 @@
-import React, { useState } from 'react';
+import React from 'react';
 import * as UI from '@/styles/ui';
 
-export default function KeyDatesCard({ applicationDate, representationDeadline, consultationDays }: { applicationDate: string; representationDeadline: string; consultationDays: number }) {
-  const [why, setWhy] = useState(false);
+export default function KeyDatesCard({
+  applicationDate,
+  representationDeadline,
+}: {
+  applicationDate: string;
+  representationDeadline: string;
+  consultationDays: number;
+}) {
   return (
     <div className={`${UI.card} ${UI.cardHover} p-4 md:p-5`} aria-label="Key dates">
       <div className="flex items-start justify-between mb-2">
         <h3 className="text-sm font-semibold text-blue-900">Key dates</h3>
         <button
           type="button"
-          onClick={() => setWhy(!why)}
-          className="text-xs underline transition-all duration-200 ease-[cubic-bezier(.2,.8,.2,1)] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white"
-          aria-expanded={why}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          title="Per Licensing Act 2003"
+          aria-label="Why these dates?"
         >
-          Why?
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="h-4 w-4"
+          >
+            <path d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M10 9v4" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M10 6h.01" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         </button>
       </div>
       <div className="text-sm text-[#192650]">Application date: {applicationDate || '—'}</div>
       <div className="text-sm mt-1 text-[#192650]">Representation deadline (per Licensing Act 2003): {representationDeadline}</div>
-      {why && (
-        <p className="mt-2 text-xs text-slate-700">
-          Deadline is the day after application plus {consultationDays} days, skipping weekends and bank holidays.
-        </p>
-      )}
     </div>
   );
 }

--- a/src/components/publish/RightRail/PreviewCard.tsx
+++ b/src/components/publish/RightRail/PreviewCard.tsx
@@ -3,21 +3,47 @@ import * as UI from '@/styles/ui';
 
 export default function PreviewCard({ text }: { text: string }) {
   const [open, setOpen] = useState(false);
+  const hasPreview = (text ?? '').trim().length > 0;
   return (
-    <div aria-label="Notice preview" className={`${UI.card} ${UI.cardHover} p-4 md:p-5 min-h-[360px] space-y-3`}>
-      <div className="flex items-center justify-between">
+    <div aria-label="Notice preview" className={`${UI.card} ${UI.cardHover} relative min-h-[360px] p-4 md:p-5 space-y-4`}>
+      <div>
         <h3 className="font-medium text-brand-navy">Preview</h3>
-        <button
-          type="button"
-          className="text-sm underline transition-all duration-200 ease-[cubic-bezier(.2,.8,.2,1)] focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white"
-          onClick={() => setOpen(true)}
-        >
-          Expand
-        </button>
+        <p className="mt-1 text-xs text-slate-600">Generated as you type</p>
       </div>
-      <p className="text-xs text-slate-600">Generated as you type</p>
-      <div className={UI.prose + ' whitespace-pre-wrap min-h-[300px]'} id="notice-preview">
-        {text}
+      <button
+        type="button"
+        className="absolute right-2 top-2 inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-600 hover:bg-white/60 focus:outline-none focus:ring-2 focus:ring-blue-600"
+        aria-label="Expand preview"
+        title="Expand preview"
+        onClick={() => setOpen(true)}
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="h-4 w-4"
+        >
+          <path d="M7.5 4H4a1 1 0 0 0-1 1v3.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M12.5 16H16a1 1 0 0 0 1-1v-3.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="m11 4 5 5" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="m4 11 5 5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      <div
+        id="notice-preview"
+        className="min-h-[300px] rounded-xl border border-slate-900/5 bg-white/80 p-4"
+      >
+        {hasPreview ? (
+          <pre className="whitespace-pre-wrap text-[13px] leading-5 text-slate-800">{text}</pre>
+        ) : (
+          <div className="space-y-2">
+            <div className="h-4 rounded bg-[linear-gradient(90deg,rgba(2,6,23,.06),rgba(2,6,23,.12),rgba(2,6,23,.06))] bg-[length:200%_100%] animate-shimmer" />
+            <div className="h-4 w-5/6 rounded bg-[linear-gradient(90deg,rgba(2,6,23,.06),rgba(2,6,23,.12),rgba(2,6,23,.06))] bg-[length:200%_100%] animate-shimmer" />
+            <div className="h-4 w-3/5 rounded bg-[linear-gradient(90deg,rgba(2,6,23,.06),rgba(2,6,23,.12),rgba(2,6,23,.06))] bg-[length:200%_100%] animate-shimmer" />
+          </div>
+        )}
       </div>
       {open && (
         <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -93,30 +93,39 @@ export default function PublishPage() {
   }, [noticeType, debounced]);
 
   const autoFocusRef = useRef<HTMLInputElement>(null);
+  const heroSteps: Array<{ label: string; status: 'current' | 'upcoming' }> = [
+    { label: 'Confirm notice type', status: 'current' },
+    { label: 'Fill notice details', status: 'upcoming' },
+    { label: 'Review & publish', status: 'upcoming' },
+  ];
 
   return (
     <div className={`${UI.pageWrapLg} relative`} data-testid="publish-layout">
       {/* Hero header */}
-      <div className={`${UI.container} pt-16 md:pt-20 pb-6`}>
+      <div className={`${UI.container} pt-16 md:pt-20 pb-10`}>
         <h1 className={`${UI.heroH1} mb-2`}>Publish a notice</h1>
         <p className={`${UI.heroSub} mt-1`}>Guided, compliant, and instant proof</p>
-        {/* Mode tabs on gradient */}
-        <nav role="tablist" className="mt-4 flex gap-2">
-          <button
-            className={`rounded-xl bg-white text-blue-900 font-semibold ring-1 ring-white/60 shadow-sm px-4 h-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-transparent`}
-            data-active={true}
-            aria-label="Upload from Notice"
-          >
-            Upload from Notice
-          </button>
-          <button
-            className={`rounded-xl bg-white/80 text-blue-800 hover:bg-white ring-1 ring-white/50 px-4 h-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-transparent`}
-            data-active={false}
-            aria-label="Upload via Template"
-          >
-            Upload via Template
-          </button>
-        </nav>
+        <ol
+          className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-white/90"
+          aria-label="Publish steps"
+        >
+          {heroSteps.map((step, idx) => (
+            <li
+              key={step.label}
+              className="flex items-center gap-x-3 md:gap-x-4"
+              aria-current={step.status === 'current' ? 'step' : undefined}
+            >
+              <span
+                aria-hidden
+                className={`${UI.stepDotBase} ${step.status === 'current' ? UI.stepDotActive : ''}`}
+              />
+              <span className={`text-sm text-white/90 ${step.status === 'current' ? 'font-semibold' : 'font-medium'}`}>
+                <span className="sr-only">Step {idx + 1}: </span>
+                {step.label}
+              </span>
+            </li>
+          ))}
+        </ol>
       </div>
       {/* Main content on light canvas */}
       <div className={`${UI.container} ${UI.sectionY} grid md:grid-cols-12 gap-8 items-start`}>
@@ -127,51 +136,49 @@ export default function PublishPage() {
         )}
 
         <main className="md:col-span-8 space-y-6">
-            {/* First form surface: Notice type selection as a real card */}
-            <section className={`${UI.card} ${UI.cardHover} p-6`}>
-              <header className="mb-3">
-                <h2 className={UI.cardHeader}>Confirm notice type</h2>
-                <p className="text-sm text-slate-600 mt-1">Start by confirming your notice type. You can change this later.</p>
-              </header>
-
-              <div className="space-y-3">
-                <NoticeTypeSelect value={noticeType} onChange={setNoticeType} />
+          <section className={`${UI.section} space-y-4`}>
+            <header className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-sm font-semibold text-blue-900">Confirm notice type</h2>
+                <p className="mt-1 text-sm text-slate-600">You can change this later.</p>
               </div>
+              <button type="button" className={`${UI.btnPrimary} h-10 py-0 shrink-0`}>
+                Continue
+              </button>
+            </header>
 
-              <footer className="mt-4 flex justify-end">
-                <button className={`${UI.btnPrimary} h-10 py-0`}>Continue</button>
-              </footer>
-            </section>
-            {noticeType === 'premises' && (
-              <PremisesForm
-                value={premisesData}
-                onChange={setPremisesData}
-                onAuthorityChange={handleAuthorityChange}
-                saving={false}
-                autoFocusRef={autoFocusRef}
-              />
-            )}
-            {noticeType === 'gvol' && (
-              <GVOLForm
-                value={gvolData}
-                onChange={setGvolData}
-                onAuthorityChange={handleAuthorityChange}
-                saving={false}
-                autoFocusRef={autoFocusRef}
-              />
-            )}
-            {noticeType === 'traffic' && (
-              <TrafficForm
-                value={trafficData}
-                onChange={setTrafficData}
-                onAuthorityChange={handleAuthorityChange}
-                saving={false}
-                autoFocusRef={autoFocusRef}
-              />
-            )}
+            <NoticeTypeSelect value={noticeType} onChange={setNoticeType} />
+          </section>
+          {noticeType === 'premises' && (
+            <PremisesForm
+              value={premisesData}
+              onChange={setPremisesData}
+              onAuthorityChange={handleAuthorityChange}
+              saving={false}
+              autoFocusRef={autoFocusRef}
+            />
+          )}
+          {noticeType === 'gvol' && (
+            <GVOLForm
+              value={gvolData}
+              onChange={setGvolData}
+              onAuthorityChange={handleAuthorityChange}
+              saving={false}
+              autoFocusRef={autoFocusRef}
+            />
+          )}
+          {noticeType === 'traffic' && (
+            <TrafficForm
+              value={trafficData}
+              onChange={setTrafficData}
+              onAuthorityChange={handleAuthorityChange}
+              saving={false}
+              autoFocusRef={autoFocusRef}
+            />
+          )}
         </main>
 
-        <aside className="md:col-span-4 md:sticky md:top-[var(--headerH)] space-y-4">
+        <aside className="md:col-span-4 md:sticky md:top-[calc(var(--headerH)+24px)] space-y-6">
           <PreviewCard text={preview} />
           <ComplianceCard items={checklist} />
           <KeyDatesCard applicationDate={premisesData?.applicationDate || ''} representationDeadline={representationDeadline} consultationDays={consultationDays} />

--- a/src/styles/ui.ts
+++ b/src/styles/ui.ts
@@ -36,8 +36,10 @@ export const btnSecondary =
 // Stepper (Publish)
 export const stepperTrack = "h-1 rounded-full bg-[rgba(25,38,80,0.12)]";
 export const stepperFill = "h-1 rounded-full bg-[#2563EB]";
-export const stepDotBase = "w-8 h-8 rounded-full grid place-items-center border border-[rgba(25,38,80,0.15)] bg-white";
-export const stepDotActive = "ring-2 ring-[#2563EB] ring-offset-2 ring-offset-white border-transparent";
+export const stepDotBase =
+  "w-8 h-8 rounded-full grid place-items-center bg-white/10 ring-1 ring-white/40";
+export const stepDotActive =
+  "bg-white ring-2 ring-[#2563EB] ring-offset-2 ring-offset-transparent";
 
 // Keep legacy exports for compatibility in existing components
 export const gradientBg = "min-h-screen bg-[linear-gradient(112deg,_#192650_0%,_#3866af_50%,_#ffffff_100%)]";


### PR DESCRIPTION
## Summary
- restyle the publish hero with a dedicated step list and move the notice type selector into a card on the canvas
- refresh right-rail cards with a preview skeleton, grouped compliance checklist, and a tooltip-style key dates icon
- tune shared stepper tokens and spacing so dots and labels stay legible against the gradient backdrop

## Testing
- npm run lint *(fails: missing @eslint/js before install; npm install blocked by 403 on registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c87370b4d0833091fe81a1b1136c8c