### PR TITLE
Polish publish experience layout and right rail

### DIFF
--- a/src/components/publish/NoticeTypeSelect.tsx
+++ b/src/components/publish/NoticeTypeSelect.tsx
@@ -6,6 +6,7 @@ export type NoticeType = 'premises' | 'traffic' | 'gvol';
 interface Props {
   value: NoticeType | '';
   onChange: (t: NoticeType) => void;
+  helperTextId?: string;
 }
 
 const options: { value: NoticeType; label: string }[] = [
@@ -14,7 +15,7 @@ const options: { value: NoticeType; label: string }[] = [
   { value: 'traffic', label: 'Traffic notice' },
 ];
 
-export default function NoticeTypeSelect({ value, onChange }: Props) {
+export default function NoticeTypeSelect({ value, onChange, helperTextId }: Props) {
   return (
     <div className="space-y-2">
       <label htmlFor="notice-type" className="block text-sm font-medium text-slate-700">
@@ -25,6 +26,7 @@ export default function NoticeTypeSelect({ value, onChange }: Props) {
         value={value}
         onChange={(e) => onChange(e.target.value as NoticeType)}
         className={`${UI.input} w-full bg-white text-[#0f172a] focus:ring-offset-transparent`}
+        aria-describedby={helperTextId}
       >
         <option value="">Select an option</option>
         {options.map((o) => (

--- a/src/components/publish/RightRail/ComplianceCard.tsx
+++ b/src/components/publish/RightRail/ComplianceCard.tsx
@@ -7,7 +7,14 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
   const allGood = unresolved.length === 0;
 
   const handleFix = (target?: string) => {
-    if (onFix) onFix(target);
+    if (onFix) {
+      onFix(target);
+      return;
+    }
+    if (!target) return;
+    const el = document.getElementById(target);
+    el?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+    (el?.querySelector('input,select,textarea,button,[tabindex]') as HTMLElement | null)?.focus?.();
   };
 
   const groupForLabel = (label: string) => {
@@ -26,10 +33,10 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
   }, {});
 
   const orderedGroups = [
-    { key: 'Applicant', label: 'Applicant' },
-    { key: 'Council', label: 'Council' },
-    { key: 'Dates', label: 'Dates' },
-    { key: 'Other', label: 'Other checks' },
+    { key: 'Applicant', label: 'APPLICANT' },
+    { key: 'Council', label: 'COUNCIL' },
+    { key: 'Dates', label: 'DATES' },
+    { key: 'Other', label: 'OTHER CHECKS' },
   ].filter((group) => grouped[group.key]?.length);
 
   return (
@@ -45,35 +52,32 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
             All checks passed — ready to publish
           </div>
         ) : (
-          <div className="space-y-3">
-            {orderedGroups.map((group, idx) => (
-              <div key={group.key} className={idx === 0 ? '' : 'pt-1'}>
-                <h4
-                  className={`text-[11px] font-semibold uppercase tracking-wide text-slate-600 ${idx === 0 ? 'mt-0' : 'mt-2'} mb-1`}
-                >
-                  {group.label}
-                </h4>
-                <div className="grid grid-cols-[1fr_auto] items-start gap-x-3 gap-y-2">
+          <div className="space-y-4">
+            {orderedGroups.map((group) => (
+              <div key={group.key}>
+                <h4 className="text-[11px] tracking-wide uppercase text-slate-500 mb-2">{group.label}</h4>
+                <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-3 gap-y-3">
                   {grouped[group.key]?.map((item) => (
                     <React.Fragment key={item.id}>
                       <span
-                        className={`text-[13px] leading-5 ${item.ok ? 'text-green-700' : 'text-slate-700'}`}
+                        className={`pl-1.5 text-[13px] leading-5 ${item.ok ? 'text-emerald-700' : 'text-slate-700'}`}
                       >
                         {item.label}
                       </span>
                       {item.ok ? (
                         <span
                           aria-hidden
-                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-600 text-white text-[10px]"
+                          className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-emerald-600 text-white text-[10px] justify-self-end"
                         >
                           ✔
                         </span>
                       ) : (
                         <button
                           type="button"
-                          className="inline-flex h-8 items-center justify-center rounded-md border border-blue-200/70 bg-white px-3 text-xs font-medium text-blue-700 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white"
+                          className="inline-flex h-9 items-center justify-center rounded-lg border border-blue-200/70 bg-white px-4 text-xs font-medium text-blue-700 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-white justify-self-end"
                           onClick={() => handleFix(item.target)}
                           data-field={item.id}
+                          aria-controls={item.target}
                         >
                           Fix this
                         </button>

--- a/src/components/publish/RightRail/PreviewCard.tsx
+++ b/src/components/publish/RightRail/PreviewCard.tsx
@@ -38,10 +38,11 @@ export default function PreviewCard({ text }: { text: string }) {
         {hasPreview ? (
           <pre className="whitespace-pre-wrap text-[13px] leading-5 text-slate-800">{text}</pre>
         ) : (
-          <div className="space-y-2">
-            <div className="h-4 rounded bg-[linear-gradient(90deg,rgba(2,6,23,.06),rgba(2,6,23,.12),rgba(2,6,23,.06))] bg-[length:200%_100%] animate-shimmer" />
-            <div className="h-4 w-5/6 rounded bg-[linear-gradient(90deg,rgba(2,6,23,.06),rgba(2,6,23,.12),rgba(2,6,23,.06))] bg-[length:200%_100%] animate-shimmer" />
-            <div className="h-4 w-3/5 rounded bg-[linear-gradient(90deg,rgba(2,6,23,.06),rgba(2,6,23,.12),rgba(2,6,23,.06))] bg-[length:200%_100%] animate-shimmer" />
+          <div className="space-y-2 animate-pulse">
+            <div className="h-3 rounded bg-slate-200/70" />
+            <div className="h-3 w-11/12 rounded bg-slate-200/70" />
+            <div className="h-3 w-9/12 rounded bg-slate-200/70" />
+            <div className="h-3 w-7/12 rounded bg-slate-200/70" />
           </div>
         )}
       </div>

--- a/src/pages/PublishPage.tsx
+++ b/src/pages/PublishPage.tsx
@@ -30,38 +30,32 @@ export default function PublishPage() {
         <h1 className={`${UI.heroH1} mb-2`}>Publish a notice</h1>
         <p className={`${UI.heroSub} mt-1`}>Guided, compliant, and instant proof</p>
         <nav role="tablist" className="mt-4 flex gap-2">
-          {(() => {
-            const activeTab = (t: 'notice' | 'template') =>
-              t === tab
-                ? "rounded-xl bg-white text-blue-900 font-semibold ring-1 ring-white/60 shadow-sm"
-                : "rounded-xl bg-white/80 text-blue-800 hover:bg-white ring-1 ring-white/50";
+          {(
+            [
+              { key: 'notice', label: 'Upload from Notice' },
+              { key: 'template', label: 'Upload via Template' },
+            ] as const
+          ).map((option) => {
+            const isActive = tab === option.key;
             return (
-              <>
-          <button
-            role="tab"
-            aria-selected={tab === 'notice'}
-            aria-controls="notice-panel"
-            tabIndex={tab === 'notice' ? 0 : -1}
-            className={`${activeTab('notice')} px-4 h-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-transparent`}
-            data-testid="tab-trigger-notice"
-            onClick={() => setTab('notice')}
-          >
-            Upload from Notice
-          </button>
-          <button
-            role="tab"
-            aria-selected={tab === 'template'}
-            aria-controls="template-panel"
-            tabIndex={tab === 'template' ? 0 : -1}
-            className={`${activeTab('template')} px-4 h-10 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-transparent`}
-            data-testid="tab-trigger-template"
-            onClick={() => setTab('template')}
-          >
-            Upload via Template
-          </button>
-              </>
+              <button
+                key={option.key}
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`${option.key}-panel`}
+                tabIndex={isActive ? 0 : -1}
+                className={`${UI.btnSecondary} h-10 px-4 text-sm transition-colors duration-200 focus:ring-offset-0 focus:ring-offset-transparent ${
+                  isActive
+                    ? 'bg-white text-blue-900 font-semibold shadow-sm border-white/70'
+                    : 'bg-white/80 text-blue-900/80 border-white/60 hover:bg-white/90'
+                }`}
+                data-testid={`tab-trigger-${option.key}`}
+                onClick={() => setTab(option.key)}
+              >
+                {option.label}
+              </button>
             );
-          })()}
+          })}
         </nav>
       </div>
       {/* Main content on light canvas */}

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -46,12 +46,42 @@ export default function PublishPage() {
     const d = premisesData;
     const postcodeRe = /[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}/i;
     return [
-      { id: 'applicant', label: 'Applicant name + postal address (incl. postcode)', ok: !!(d?.applicantName && postcodeRe.test(d?.applicantPostcode || '')) },
-      { id: 'premises', label: 'Premises address (incl. postcode)', ok: !!(d?.premisesAddress && postcodeRe.test(d?.postcode || '')) },
-      { id: 'council', label: 'Council selected + email present', ok: !!(d?.councilName && /[^@\s]+@[^@\s]+\.[^@\s]+/.test(d?.councilEmail || '')) },
-      { id: 'dates', label: 'Application date set + deadline computed correctly', ok: !!(d?.applicationDate && representationDeadline) },
-      { id: 'activities', label: 'If any activity is enabled, weekly hours valid', ok: (d?.activities?.length || 0) > 0 && !issues.some((i) => /Activity.*invalid|licensable activity/i.test(i.message)) },
-      { id: 'boilerplate', label: 'Statutory boilerplate present in preview', ok: /It is an offence to knowingly or recklessly make a false statement/i.test(preview) },
+      {
+        id: 'applicant',
+        label: 'Applicant name + postal address (incl. postcode)',
+        ok: !!(d?.applicantName && postcodeRe.test(d?.applicantPostcode || '')),
+        target: 'applicantName',
+      },
+      {
+        id: 'premises',
+        label: 'Premises address (incl. postcode)',
+        ok: !!(d?.premisesAddress && postcodeRe.test(d?.postcode || '')),
+        target: 'premises-address',
+      },
+      {
+        id: 'council',
+        label: 'Council selected + email present',
+        ok: !!(d?.councilName && /[^@\s]+@[^@\s]+\.[^@\s]+/.test(d?.councilEmail || '')),
+        target: 'council',
+      },
+      {
+        id: 'dates',
+        label: 'Application date set + deadline computed correctly',
+        ok: !!(d?.applicationDate && representationDeadline),
+        target: 'applicationDate',
+      },
+      {
+        id: 'activities',
+        label: 'If any activity is enabled, weekly hours valid',
+        ok: (d?.activities?.length || 0) > 0 && !issues.some((i) => /Activity.*invalid|licensable activity/i.test(i.message)),
+        target: 'activities-grid',
+      },
+      {
+        id: 'boilerplate',
+        label: 'Statutory boilerplate present in preview',
+        ok: /It is an offence to knowingly or recklessly make a false statement/i.test(preview),
+        target: 'notice-preview',
+      },
     ];
   }, [premisesData, representationDeadline, issues, preview]);
   const canSubmit = checklist.every((c) => c.ok);
@@ -98,37 +128,51 @@ export default function PublishPage() {
     { label: 'Fill notice details', status: 'upcoming' },
     { label: 'Review & publish', status: 'upcoming' },
   ];
+  const noticeTypeHelpId = 'notice-type-help';
 
   return (
     <div className={`${UI.pageWrapLg} relative`} data-testid="publish-layout">
       {/* Hero header */}
-      <div className={`${UI.container} pt-16 md:pt-20 pb-10`}>
+      <div className={`${UI.container} pt-16 md:pt-20 pb-8`}>
         <h1 className={`${UI.heroH1} mb-2`}>Publish a notice</h1>
         <p className={`${UI.heroSub} mt-1`}>Guided, compliant, and instant proof</p>
-        <ol
-          className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-white/90"
-          aria-label="Publish steps"
-        >
-          {heroSteps.map((step, idx) => (
-            <li
-              key={step.label}
-              className="flex items-center gap-x-3 md:gap-x-4"
-              aria-current={step.status === 'current' ? 'step' : undefined}
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-x-0 top-1/2 -translate-y-1/2" aria-hidden>
+              <div className={`${UI.stepperTrack}`} />
+            </div>
+            <ol
+              className="relative z-10 flex flex-wrap items-center gap-x-6 gap-y-4 text-white/90"
+              aria-label="Publish steps"
             >
-              <span
-                aria-hidden
-                className={`${UI.stepDotBase} ${step.status === 'current' ? UI.stepDotActive : ''}`}
-              />
-              <span className={`text-sm text-white/90 ${step.status === 'current' ? 'font-semibold' : 'font-medium'}`}>
-                <span className="sr-only">Step {idx + 1}: </span>
-                {step.label}
-              </span>
-            </li>
-          ))}
-        </ol>
+              {heroSteps.map((step, idx) => {
+                const isCurrent = step.status === 'current';
+                return (
+                  <li key={step.label} className="flex items-center gap-x-3 md:gap-x-4">
+                    <span
+                      className={`${UI.stepDot} ${isCurrent ? UI.stepDotActive : ''} transition-all duration-200`}
+                      aria-current={isCurrent ? 'step' : undefined}
+                      data-active={isCurrent ? 'true' : undefined}
+                    >
+                      <span
+                        className={`h-2.5 w-2.5 rounded-full transition-colors duration-200 ${
+                          isCurrent ? 'bg-blue-600' : 'bg-slate-400/70'
+                        }`}
+                      />
+                    </span>
+                    <span className={`text-sm ${isCurrent ? 'font-semibold text-white' : 'font-medium text-white/80'}`}>
+                      <span className="sr-only">Step {idx + 1}: </span>
+                      {step.label}
+                    </span>
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+        </div>
       </div>
       {/* Main content on light canvas */}
-      <div className={`${UI.container} ${UI.sectionY} grid md:grid-cols-12 gap-8 items-start`}>
+      <div className={`${UI.container} ${UI.sectionY} pt-12 md:pt-16 lg:pt-20 grid md:grid-cols-12 gap-8 items-start`}>
         {issues.length > 0 && (
           <div className="md:col-span-12">
             <ErrorSummary errors={issues} />
@@ -147,7 +191,10 @@ export default function PublishPage() {
               </button>
             </header>
 
-            <NoticeTypeSelect value={noticeType} onChange={setNoticeType} />
+            <div>
+              <NoticeTypeSelect value={noticeType} onChange={setNoticeType} helperTextId={noticeTypeHelpId} />
+              <p id={noticeTypeHelpId} className="mt-1 text-xs text-slate-600">We'll tailor the form to this type.</p>
+            </div>
           </section>
           {noticeType === 'premises' && (
             <PremisesForm
@@ -178,10 +225,14 @@ export default function PublishPage() {
           )}
         </main>
 
-        <aside className="md:col-span-4 md:sticky md:top-[calc(var(--headerH)+24px)] space-y-6">
+        <aside className="md:col-span-4 md:sticky md:top-24 space-y-4">
           <PreviewCard text={preview} />
           <ComplianceCard items={checklist} />
-          <KeyDatesCard applicationDate={premisesData?.applicationDate || ''} representationDeadline={representationDeadline} consultationDays={consultationDays} />
+          <KeyDatesCard
+            applicationDate={premisesData?.applicationDate || ''}
+            representationDeadline={representationDeadline}
+            consultationDays={consultationDays}
+          />
           <CostCard cost={cost} canSubmit={canSubmit} />
         </aside>
       </div>

--- a/src/styles/ui.ts
+++ b/src/styles/ui.ts
@@ -34,12 +34,12 @@ export const btnSecondary =
   "inline-flex items-center justify-center px-5 py-3 rounded-xl bg-white text-[#192650] font-medium border border-[rgba(25,38,80,0.10)] hover:border-[rgba(25,38,80,0.20)] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white";
 
 // Stepper (Publish)
-export const stepperTrack = "h-1 rounded-full bg-[rgba(25,38,80,0.12)]";
+export const stepperTrack = "relative h-1 w-full rounded-full bg-blue-600/15";
 export const stepperFill = "h-1 rounded-full bg-[#2563EB]";
-export const stepDotBase =
-  "w-8 h-8 rounded-full grid place-items-center bg-white/10 ring-1 ring-white/40";
+export const stepDot = "w-8 h-8 rounded-full grid place-items-center border border-slate-200 bg-white";
 export const stepDotActive =
-  "bg-white ring-2 ring-[#2563EB] ring-offset-2 ring-offset-transparent";
+  "w-9 h-9 ring-2 ring-blue-600 ring-offset-2 ring-offset-white text-blue-700 border-transparent";
+export const stepDotBase = stepDot;
 
 // Keep legacy exports for compatibility in existing components
 export const gradientBg = "min-h-screen bg-[linear-gradient(112deg,_#192650_0%,_#3866af_50%,_#ffffff_100%)]";


### PR DESCRIPTION
## Summary
- refresh the publish hero layout with a connected stepper, tighter spacing, and clearer tab/button hierarchy
- tune the right-rail cards with sticky offset, grouped checklist styling, and a skeleton preview when empty
- wire helper/aria attributes so notice type guidance and “Fix this” buttons point at their fields while keeping focus rings consistent

## Testing
- `npm run lint` *(fails: missing npm dependencies; npm install blocked with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c87992ed808330aabccdd1206b50ff