### PR TITLE
Polish publish layout spacing and right rail UI

### DIFF
--- a/src/components/publish/RightRail/ComplianceCard.tsx
+++ b/src/components/publish/RightRail/ComplianceCard.tsx
@@ -33,10 +33,10 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
   }, {});
 
   const orderedGroups = [
-    { key: 'Applicant', label: 'APPLICANT' },
-    { key: 'Council', label: 'COUNCIL' },
-    { key: 'Dates', label: 'DATES' },
-    { key: 'Other', label: 'OTHER CHECKS' },
+    { key: 'Applicant', label: 'Applicant' },
+    { key: 'Council', label: 'Council' },
+    { key: 'Dates', label: 'Dates' },
+    { key: 'Other', label: 'Other checks' },
   ].filter((group) => grouped[group.key]?.length);
 
   return (
@@ -55,7 +55,7 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
           <div className="space-y-4">
             {orderedGroups.map((group) => (
               <div key={group.key}>
-                <h4 className="text-[11px] tracking-wide uppercase text-slate-500 mb-2">{group.label}</h4>
+                <h4 className="mb-2 text-[13px] font-medium text-slate-800 tracking-normal">{group.label}</h4>
                 <div className="space-y-1">
                   {grouped[group.key]?.map((item) => (
                     <div key={item.id} className="flex items-center py-1.5">
@@ -67,14 +67,14 @@ export default function ComplianceCard({ items, onFix }: { items: ChecklistItem[
                       {item.ok ? (
                         <span
                           aria-hidden
-                          className="inline-flex h-6 w-[64px] items-center justify-end text-emerald-600"
+                          className="inline-flex h-6 w-[64px] shrink-0 items-center justify-center text-emerald-600"
                         >
                           ✔
                         </span>
                       ) : (
                         <button
                           type="button"
-                          className="inline-flex h-9 w-[64px] items-center justify-end text-xs text-blue-700 underline underline-offset-2 hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-white"
+                          className="w-[64px] shrink-0 inline-flex h-9 items-center justify-center text-xs text-blue-700 underline underline-offset-2 hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-white"
                           onClick={() => handleFix(item.target)}
                           data-field={item.id}
                           aria-controls={item.target}

--- a/src/components/publish/RightRail/PreviewCard.tsx
+++ b/src/components/publish/RightRail/PreviewCard.tsx
@@ -6,31 +6,33 @@ export default function PreviewCard({ text }: { text: string }) {
   const hasPreview = (text ?? '').trim().length > 0;
   return (
     <div aria-label="Notice preview" className={`${UI.card} ${UI.cardHover} relative min-h-[360px] p-4 md:p-5 space-y-4`}>
-      <div>
-        <h3 className="font-medium text-brand-navy">Preview</h3>
-        <p className="mt-1 text-xs text-slate-600">Generated as you type</p>
-      </div>
-      <button
-        type="button"
-        className="absolute right-2 top-2 inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-600 hover:bg-white/60 focus:outline-none focus:ring-2 focus:ring-blue-600"
-        aria-label="Expand preview"
-        title="Expand preview"
-        onClick={() => setOpen(true)}
-      >
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 20 20"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          className="h-4 w-4"
+      <div className="flex items-center justify-between pb-2 mb-2 border-b border-slate-200/80">
+        <div>
+          <h3 className="text-[13px] font-medium text-slate-700">Preview</h3>
+          <p className="mt-1 text-xs text-slate-600">Generated as you type</p>
+        </div>
+        <button
+          type="button"
+          className="ml-4 inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-600 hover:bg-white/60 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          aria-label="Expand preview"
+          title="Expand preview"
+          onClick={() => setOpen(true)}
         >
-          <path d="M7.5 4H4a1 1 0 0 0-1 1v3.5" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="M12.5 16H16a1 1 0 0 0 1-1v-3.5" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="m11 4 5 5" strokeLinecap="round" strokeLinejoin="round" />
-          <path d="m4 11 5 5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      </button>
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="h-4 w-4"
+          >
+            <path d="M7.5 4H4a1 1 0 0 0-1 1v3.5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M12.5 16H16a1 1 0 0 0 1-1v-3.5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="m11 4 5 5" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="m4 11 5 5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+      </div>
       <div
         id="notice-preview"
         className="min-h-[300px] rounded-xl border border-slate-900/5 bg-white/80 p-4"

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -140,7 +140,7 @@ export default function PublishPage() {
   return (
     <div className={`${UI.pageWrapLg} relative`} data-testid="publish-layout">
       {/* Hero header */}
-      <div className={`${UI.container} pt-16 md:pt-20 pb-8`}>
+      <div className={`${UI.container} pt-16 md:pt-20 pb-4`}>
         <h1 className={`${UI.heroH1} mb-2`}>Publish a notice</h1>
         <p className={`${UI.heroSub} mt-1`}>Guided, compliant, and instant proof</p>
         <div className="mt-6">
@@ -200,7 +200,12 @@ export default function PublishPage() {
 
               <div>
                 <NoticeTypeSelect value={noticeType} onChange={handleNoticeTypeChange} helperTextId={noticeTypeHelpId} />
-                <p id={noticeTypeHelpId} className="mt-1 text-xs text-slate-600">We'll tailor the form to this type.</p>
+                <p
+                  id={noticeTypeHelpId}
+                  className="mt-2 text-[13px] leading-5 text-slate-600"
+                >
+                  We'll tailor the form to this type.
+                </p>
               </div>
             </div>
           </section>

--- a/src/styles/ui.ts
+++ b/src/styles/ui.ts
@@ -33,7 +33,7 @@ export const btnSecondary =
   "inline-flex items-center justify-center px-5 py-3 rounded-xl bg-white text-[#192650] font-medium border border-[rgba(25,38,80,0.10)] hover:border-[rgba(25,38,80,0.20)] transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white";
 
 // Stepper (Publish)
-export const stepperTrack = "relative h-1 rounded-full bg-blue-600/15";
+export const stepperTrack = "h-1 rounded-full bg-blue-600/20";
 export const stepperFill = "h-1 rounded-full bg-[#2563EB]";
 export const stepDot = "w-8 h-8 rounded-full grid place-items-center border border-slate-200 bg-white";
 export const stepDotActive =


### PR DESCRIPTION
## Summary
- tighten the publish hero spacing and add refined helper text for notice type selection
- refresh the stepper rail token and compliance checklist headings/button alignment
- add a divider to the preview card header for clearer separation

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c883315984833084fc845a87480a03