### PR TITLE
Implement licensing notice type step guardrails

### DIFF
--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -12,7 +12,9 @@ import type { NoticeDraft, NoticeType } from '@/types/notice';
 import { sha256Hex } from '@/lib/hash';
 import ApplicantCouncilSection from './sections/ApplicantCouncilSection';
 import ApplicationBasicsSection from './sections/ApplicationBasicsSection';
-import NoticeTypeStep from './sections/NoticeTypeStep';
+// CN:STEP1-START
+import NoticeTypeStep, { isLicensingNoticeType } from './sections/NoticeTypeStep';
+// CN:STEP1-END
 
 export default function UploadNoticeFlow() {
   const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
@@ -32,6 +34,10 @@ export default function UploadNoticeFlow() {
     status: 'Draft',
     applicationDate: '',
   });
+  // CN:STEP1-START
+  const noticeTypeRef = React.useRef<HTMLSelectElement>(null);
+  const [noticeTypeError, setNoticeTypeError] = useState('');
+  // CN:STEP1-END
   const [confirmA, setConfirmA] = useState(false);
   const [confirmB, setConfirmB] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -54,16 +60,29 @@ export default function UploadNoticeFlow() {
 
   const handleBack = () => setStep((prev) => Math.max(1, (prev as number) - 1) as 1 | 2 | 3 | 4);
   const handleNext = () => setStep((prev) => Math.min(4, (prev as number) + 1) as 1 | 2 | 3 | 4);
+  // CN:STEP1-START
+  const handleContinueFromStep1 = () => {
+    if (!isLicensingNoticeType(draft.noticeType)) {
+      setNoticeTypeError('Select a notice type to continue.');
+      noticeTypeRef.current?.focus();
+      return;
+    }
+    setNoticeTypeError('');
+    setStep(2);
+  };
+  const canContinueFromStep1 = isLicensingNoticeType(draft.noticeType);
+  // CN:STEP1-END
 
+  // CN:STEP1-START
   // On mount: read ?type= and set draft.noticeType if valid
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const t = params.get('type');
-    const allowed: NoticeType[] = ['premises','gvol','tro','planning','gambling','probate','other'];
-    if (t && (allowed as string[]).includes(t)) {
+    const t = params.get('type') ?? undefined;
+    if (isLicensingNoticeType(t)) {
       setDraft((d) => ({ ...d, noticeType: t as NoticeType }));
     }
   }, []);
+  // CN:STEP1-END
 
   // Auto-lookup council when postcode changes (defensive)
   useEffect(() => {
@@ -130,10 +149,14 @@ export default function UploadNoticeFlow() {
             totalSteps={4}
             labels={['Confirm Notice Type','Upload your Notice','Confirm your Notice','Pay']}
           />
+          // CN:STEP1-START
           {step === 1 && (
             <>
               <NoticeTypeStep
+                ref={noticeTypeRef}
                 value={draft.noticeType}
+                error={noticeTypeError}
+                onResetError={() => setNoticeTypeError('')}
                 onChange={(t) => {
                   setDraft((d) => ({ ...d, noticeType: t }));
                   const params = new URLSearchParams(window.location.search);
@@ -143,16 +166,18 @@ export default function UploadNoticeFlow() {
               />
               <div className="mt-4">
                 <button
-                  className={UI.btnPrimary}
+                  type="button"
+                  className={`${UI.btnPrimary} ${!canContinueFromStep1 ? 'cursor-not-allowed opacity-60' : ''}`}
                   data-testid="btn-continue-step1"
-                  onClick={() => setStep(2)}
-                  disabled={!draft.noticeType}
+                  onClick={handleContinueFromStep1}
+                  aria-disabled={!canContinueFromStep1}
                 >
                   Continue
                 </button>
               </div>
             </>
           )}
+          // CN:STEP1-END
           {step === 2 && (
             <>
               <FileDropOCR

--- a/src/components/publish/sections/NoticeTypeStep.tsx
+++ b/src/components/publish/sections/NoticeTypeStep.tsx
@@ -1,33 +1,176 @@
+import React, { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Info } from 'lucide-react';
 import * as UI from '@/styles/ui';
 import type { NoticeType } from '@/types/notice';
 
-export default function NoticeTypeStep({
-  value,
-  onChange,
-}: { value?: NoticeType; onChange: (t: NoticeType) => void }) {
-  return (
-    <section className={UI.card + ' p-5 md:p-6'} data-testid="notice-type-step">
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold">Confirm Notice Type</h2>
-      </div>
-      <div className="mt-3">
-        <select
-          className={UI.input}
-          value={value ?? ''}
-          onChange={(e) => onChange(e.target.value as NoticeType)}
-          data-testid="select-notice-type"
-        >
-          <option value="" disabled>Select a type…</option>
-          <option value="premises">Premises Licence (Licensing Act 2003)</option>
-          <option value="gvol">Goods Vehicle Operator</option>
-          <option value="tro">Traffic Regulation Order</option>
-          <option value="planning">Planning</option>
-          <option value="gambling">Gambling</option>
-          <option value="probate">Probate</option>
-          <option value="other">Other</option>
-        </select>
-      </div>
-    </section>
-  );
+// CN:STEP1-START
+export const LICENSING_NOTICE_TYPES = ['premises', 'variation', 'review'] as const;
+export type LicensingNoticeType = (typeof LICENSING_NOTICE_TYPES)[number];
+export const isLicensingNoticeType = (value: unknown): value is LicensingNoticeType =>
+  LICENSING_NOTICE_TYPES.includes(value as LicensingNoticeType);
+
+type Props = {
+  value?: NoticeType;
+  onChange: (t: NoticeType) => void;
+  error?: string;
+  onResetError?: () => void;
+};
+
+type Option = {
+  value: LicensingNoticeType;
+  label: string;
+  descriptor: string;
+};
+
+const OPTIONS: Option[] = [
+  {
+    value: 'premises',
+    label: 'Premises Licence — Licensing Act 2003 (Alcohol/regulated entertainment & late-night refreshment)',
+    descriptor: 'Licensing Act 2003 (Alcohol/regulated entertainment & late-night refreshment)',
+  },
+  {
+    value: 'variation',
+    label: 'Variation of Premises Licence — Licensing Act 2003 (Changes to hours/conditions/layout, etc.)',
+    descriptor: 'Licensing Act 2003 (Changes to hours/conditions/layout, etc.)',
+  },
+  {
+    value: 'review',
+    label: 'Review of Premises Licence — Licensing Act 2003 (Application to review an existing licence)',
+    descriptor: 'Licensing Act 2003 (Application to review an existing licence)',
+  },
+];
+
+function useTooltipControls() {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickAway = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!panelRef.current || panelRef.current.contains(target)) return;
+      if (buttonRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickAway);
+    return () => document.removeEventListener('mousedown', handleClickAway);
+  }, [open]);
+
+  return { open, setOpen, panelRef, buttonRef };
 }
 
+const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
+  ({ value, onChange, error, onResetError }, ref) => {
+    const selectId = useId();
+    const helperId = useId();
+    const errorId = useId();
+    const tooltipId = useId();
+    const { open, setOpen, panelRef, buttonRef } = useTooltipControls();
+
+    const licensingValue = isLicensingNoticeType(value) ? value : undefined;
+
+    const descriptor = useMemo(() => {
+      if (!licensingValue) return undefined;
+      return OPTIONS.find((option) => option.value === licensingValue)?.descriptor;
+    }, [licensingValue]);
+
+    const describedBy = [descriptor ? helperId : undefined, error ? errorId : undefined]
+      .filter(Boolean)
+      .join(' ');
+
+    return (
+      <section className={UI.card + ' p-5 md:p-6'} data-testid="notice-type-step">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">Confirm Notice Type</h2>
+          <div className="relative">
+            <button
+              type="button"
+              ref={buttonRef}
+              aria-label="Read more about notice types"
+              aria-expanded={open}
+              aria-controls={tooltipId}
+              onClick={() => setOpen((prev) => !prev)}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-brand-blue/40 text-brand-blue transition hover:bg-brand-blue/10 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white"
+            >
+              <Info aria-hidden="true" className="h-4 w-4" />
+            </button>
+            {open && (
+              <div
+                id={tooltipId}
+                role="tooltip"
+                ref={panelRef}
+                className="absolute right-0 z-20 mt-2 w-72 max-w-xs rounded-xl border border-brand-blue/20 bg-white p-4 text-sm text-brand-navy shadow-[0_10px_28px_rgba(25,38,80,0.14)]"
+              >
+                <p>Choose the exact Licensing Act 2003 category. This controls required wording and deadlines later.</p>
+                <a
+                  href="/docs/licensing-act-2003/premises-notices"
+                  className="mt-3 inline-flex items-center font-medium text-[#2563EB] hover:underline"
+                >
+                  Read the guidance
+                </a>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          <label htmlFor={selectId} className={UI.label}>
+            Notice type
+          </label>
+          <select
+            id={selectId}
+            ref={ref}
+            className={`${UI.input} w-full bg-white text-[#0f172a] focus:ring-offset-transparent`}
+            value={licensingValue ?? ''}
+            onChange={(event) => {
+              onResetError?.();
+              const nextValue = event.target.value as LicensingNoticeType | '';
+              if (!nextValue) {
+                return;
+              }
+              onChange(nextValue as NoticeType);
+            }}
+            aria-invalid={Boolean(error)}
+            aria-describedby={describedBy || undefined}
+            data-testid="select-notice-type"
+          >
+            <option value="" disabled>
+              Select a notice type…
+            </option>
+            {OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {descriptor && (
+            <p id={helperId} className="text-sm text-brand-gray">
+              {descriptor}
+            </p>
+          )}
+          {error && (
+            <p id={errorId} className="text-sm text-red-600">
+              {error}
+            </p>
+          )}
+        </div>
+      </section>
+    );
+  }
+);
+
+export default NoticeTypeStep;
+// CN:STEP1-END


### PR DESCRIPTION
## Summary
- replace the notice type step with a licensing-specific selector, helper copy, and accessible tooltip
- integrate step-one validation into the upload flow, including inline errors, focus handling, and continue gating

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' in current environment)*
- npm run test *(fails: vitest is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95c059f688330a79800926f08e474