### PR TITLE
Fix notice type step validation and help tooltip

### DIFF
--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -12,9 +12,9 @@ import type { NoticeDraft, NoticeType } from '@/types/notice';
 import { sha256Hex } from '@/lib/hash';
 import ApplicantCouncilSection from './sections/ApplicantCouncilSection';
 import ApplicationBasicsSection from './sections/ApplicationBasicsSection';
-// CN:STEP1-START
+/* CN:STEP1-START */
 import NoticeTypeStep, { isLicensingNoticeType } from './sections/NoticeTypeStep';
-// CN:STEP1-END
+/* CN:STEP1-END */
 
 export default function UploadNoticeFlow() {
   const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
@@ -34,10 +34,6 @@ export default function UploadNoticeFlow() {
     status: 'Draft',
     applicationDate: '',
   });
-  // CN:STEP1-START
-  const noticeTypeRef = React.useRef<HTMLSelectElement>(null);
-  const [noticeTypeError, setNoticeTypeError] = useState('');
-  // CN:STEP1-END
   const [confirmA, setConfirmA] = useState(false);
   const [confirmB, setConfirmB] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -60,20 +56,8 @@ export default function UploadNoticeFlow() {
 
   const handleBack = () => setStep((prev) => Math.max(1, (prev as number) - 1) as 1 | 2 | 3 | 4);
   const handleNext = () => setStep((prev) => Math.min(4, (prev as number) + 1) as 1 | 2 | 3 | 4);
-  // CN:STEP1-START
-  const handleContinueFromStep1 = () => {
-    if (!isLicensingNoticeType(draft.noticeType)) {
-      setNoticeTypeError('Select a notice type to continue.');
-      noticeTypeRef.current?.focus();
-      return;
-    }
-    setNoticeTypeError('');
-    setStep(2);
-  };
-  const canContinueFromStep1 = isLicensingNoticeType(draft.noticeType);
-  // CN:STEP1-END
 
-  // CN:STEP1-START
+  /* CN:STEP1-START */
   // On mount: read ?type= and set draft.noticeType if valid
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -82,7 +66,7 @@ export default function UploadNoticeFlow() {
       setDraft((d) => ({ ...d, noticeType: t as NoticeType }));
     }
   }, []);
-  // CN:STEP1-END
+  /* CN:STEP1-END */
 
   // Auto-lookup council when postcode changes (defensive)
   useEffect(() => {
@@ -149,35 +133,20 @@ export default function UploadNoticeFlow() {
             totalSteps={4}
             labels={['Confirm Notice Type','Upload your Notice','Confirm your Notice','Pay']}
           />
-          // CN:STEP1-START
+          {/* CN:STEP1-START */}
           {step === 1 && (
-            <>
-              <NoticeTypeStep
-                ref={noticeTypeRef}
-                value={draft.noticeType}
-                error={noticeTypeError}
-                onResetError={() => setNoticeTypeError('')}
-                onChange={(t) => {
-                  setDraft((d) => ({ ...d, noticeType: t }));
-                  const params = new URLSearchParams(window.location.search);
-                  params.set('type', t);
-                  window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
-                }}
-              />
-              <div className="mt-4">
-                <button
-                  type="button"
-                  className={`${UI.btnPrimary} ${!canContinueFromStep1 ? 'cursor-not-allowed opacity-60' : ''}`}
-                  data-testid="btn-continue-step1"
-                  onClick={handleContinueFromStep1}
-                  aria-disabled={!canContinueFromStep1}
-                >
-                  Continue
-                </button>
-              </div>
-            </>
+            <NoticeTypeStep
+              value={draft.noticeType}
+              onChange={(t) => {
+                setDraft((d) => ({ ...d, noticeType: t }));
+                const params = new URLSearchParams(window.location.search);
+                params.set('type', t);
+                window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+              }}
+              onContinue={() => setStep(2)}
+            />
           )}
-          // CN:STEP1-END
+          {/* CN:STEP1-END */}
           {step === 2 && (
             <>
               <FileDropOCR

--- a/src/components/publish/sections/NoticeTypeStep.tsx
+++ b/src/components/publish/sections/NoticeTypeStep.tsx
@@ -1,9 +1,7 @@
-import React, { forwardRef, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Info } from 'lucide-react';
+import React, { forwardRef, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import * as UI from '@/styles/ui';
 import type { NoticeType } from '@/types/notice';
 
-// CN:STEP1-START
 export const LICENSING_NOTICE_TYPES = ['premises', 'variation', 'review'] as const;
 export type LicensingNoticeType = (typeof LICENSING_NOTICE_TYPES)[number];
 export const isLicensingNoticeType = (value: unknown): value is LicensingNoticeType =>
@@ -12,8 +10,8 @@ export const isLicensingNoticeType = (value: unknown): value is LicensingNoticeT
 type Props = {
   value?: NoticeType;
   onChange: (t: NoticeType) => void;
-  error?: string;
-  onResetError?: () => void;
+  onContinue: () => void;
+  suppressInlineHelp?: boolean;
 };
 
 type Option = {
@@ -25,18 +23,18 @@ type Option = {
 const OPTIONS: Option[] = [
   {
     value: 'premises',
-    label: 'Premises Licence — Licensing Act 2003 (Alcohol/regulated entertainment & late-night refreshment)',
-    descriptor: 'Licensing Act 2003 (Alcohol/regulated entertainment & late-night refreshment)',
+    label: 'Premises Licence — Licensing Act 2003',
+    descriptor: 'Alcohol/regulated entertainment & late-night refreshment.',
   },
   {
     value: 'variation',
-    label: 'Variation of Premises Licence — Licensing Act 2003 (Changes to hours/conditions/layout, etc.)',
-    descriptor: 'Licensing Act 2003 (Changes to hours/conditions/layout, etc.)',
+    label: 'Variation of Premises Licence — Licensing Act 2003',
+    descriptor: 'Changes to hours/conditions/layout, etc.',
   },
   {
     value: 'review',
-    label: 'Review of Premises Licence — Licensing Act 2003 (Application to review an existing licence)',
-    descriptor: 'Licensing Act 2003 (Application to review an existing licence)',
+    label: 'Review of Premises Licence — Licensing Act 2003',
+    descriptor: 'Application to review an existing licence.',
   },
 ];
 
@@ -60,117 +58,180 @@ function useTooltipControls() {
 
   useEffect(() => {
     if (!open) return;
-    const handleClickAway = (event: MouseEvent) => {
+    const handlePointerDown = (event: MouseEvent | PointerEvent | TouchEvent) => {
       const target = event.target as Node | null;
       if (!panelRef.current || panelRef.current.contains(target)) return;
       if (buttonRef.current?.contains(target)) return;
       setOpen(false);
     };
-    document.addEventListener('mousedown', handleClickAway);
-    return () => document.removeEventListener('mousedown', handleClickAway);
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as Node | null;
+      if (panelRef.current?.contains(target)) return;
+      if (buttonRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('focusin', handleFocusIn);
+    return () => document.removeEventListener('focusin', handleFocusIn);
   }, [open]);
 
   return { open, setOpen, panelRef, buttonRef };
 }
 
 const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
-  ({ value, onChange, error, onResetError }, ref) => {
+  ({ value, onChange, onContinue, suppressInlineHelp = false }, ref) => {
     const selectId = useId();
     const helperId = useId();
     const errorId = useId();
     const tooltipId = useId();
     const { open, setOpen, panelRef, buttonRef } = useTooltipControls();
+    const selectRef = useRef<HTMLSelectElement | null>(null);
+    const [touched, setTouched] = useState(false);
 
-    const licensingValue = isLicensingNoticeType(value) ? value : undefined;
+    const licensingValue = isLicensingNoticeType(value) ? value : '';
+    const isValid = licensingValue !== '';
 
     const descriptor = useMemo(() => {
       if (!licensingValue) return undefined;
       return OPTIONS.find((option) => option.value === licensingValue)?.descriptor;
     }, [licensingValue]);
 
-    const describedBy = [descriptor ? helperId : undefined, error ? errorId : undefined]
+    const hasError = touched && !isValid;
+    const describedBy = [descriptor ? helperId : undefined, hasError ? errorId : undefined]
       .filter(Boolean)
       .join(' ');
 
+    useImperativeHandle(ref, () => selectRef.current as HTMLSelectElement | null);
+
+    useEffect(() => {
+      if (!suppressInlineHelp) return;
+      if (!open) return;
+      setOpen(false);
+    }, [open, setOpen, suppressInlineHelp]);
+
+    const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const nextValue = event.target.value as LicensingNoticeType | '';
+      if (!nextValue) {
+        setTouched(false);
+        return;
+      }
+      setTouched(false);
+      onChange(nextValue as NoticeType);
+    };
+
+    const handleContinue = () => {
+      if (!isValid) {
+        setTouched(true);
+        selectRef.current?.focus();
+        return;
+      }
+      onContinue();
+    };
+
     return (
-      <section className={UI.card + ' p-5 md:p-6'} data-testid="notice-type-step">
-        <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold">Confirm Notice Type</h2>
-          <div className="relative">
-            <button
-              type="button"
-              ref={buttonRef}
-              aria-label="Read more about notice types"
-              aria-expanded={open}
-              aria-controls={tooltipId}
-              onClick={() => setOpen((prev) => !prev)}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-brand-blue/40 text-brand-blue transition hover:bg-brand-blue/10 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white"
-            >
-              <Info aria-hidden="true" className="h-4 w-4" />
-            </button>
-            {open && (
-              <div
-                id={tooltipId}
-                role="tooltip"
-                ref={panelRef}
-                className="absolute right-0 z-20 mt-2 w-72 max-w-xs rounded-xl border border-brand-blue/20 bg-white p-4 text-sm text-brand-navy shadow-[0_10px_28px_rgba(25,38,80,0.14)]"
-              >
-                <p>Choose the exact Licensing Act 2003 category. This controls required wording and deadlines later.</p>
-                <a
-                  href="/docs/licensing-act-2003/premises-notices"
-                  className="mt-3 inline-flex items-center font-medium text-[#2563EB] hover:underline"
+      <>
+        {/* CN:STEP1-START */}
+        <section className={UI.card + ' p-5 md:p-6'} data-testid="notice-type-step">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold">Confirm Notice Type</h2>
+            {!suppressInlineHelp && (
+              <div className="relative">
+                <button
+                  type="button"
+                  ref={buttonRef}
+                  aria-label="Read more about notice types"
+                  aria-expanded={open}
+                  aria-controls={tooltipId}
+                  onClick={() => setOpen((prev) => !prev)}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-brand-blue/40 text-brand-blue transition hover:bg-brand-blue/10 focus:outline-none focus:ring-2 focus:ring-[#2563EB] focus:ring-offset-2 focus:ring-offset-white"
                 >
-                  Read the guidance
-                </a>
+                  <span aria-hidden="true" className="text-sm font-semibold">
+                    i
+                  </span>
+                </button>
+                {open && (
+                  <div
+                    id={tooltipId}
+                    role="tooltip"
+                    ref={panelRef}
+                    tabIndex={-1}
+                    className="absolute right-0 z-20 mt-2 w-72 max-w-xs rounded-xl border border-brand-blue/20 bg-white p-4 text-sm text-brand-navy shadow-[0_10px_28px_rgba(25,38,80,0.14)]"
+                  >
+                    <p>
+                      Choose the exact Licensing Act 2003 category. This controls the required wording and deadlines later.
+                    </p>
+                    <a
+                      href="/docs/licensing-act-2003/premises-notices"
+                      className="mt-3 inline-flex items-center font-medium text-[#2563EB] hover:underline"
+                    >
+                      Read the guidance
+                    </a>
+                  </div>
+                )}
               </div>
             )}
           </div>
-        </div>
-        <div className="mt-4 space-y-2">
-          <label htmlFor={selectId} className={UI.label}>
-            Notice type
-          </label>
-          <select
-            id={selectId}
-            ref={ref}
-            className={`${UI.input} w-full bg-white text-[#0f172a] focus:ring-offset-transparent`}
-            value={licensingValue ?? ''}
-            onChange={(event) => {
-              onResetError?.();
-              const nextValue = event.target.value as LicensingNoticeType | '';
-              if (!nextValue) {
-                return;
-              }
-              onChange(nextValue as NoticeType);
-            }}
-            aria-invalid={Boolean(error)}
-            aria-describedby={describedBy || undefined}
-            data-testid="select-notice-type"
-          >
-            <option value="" disabled>
-              Select a notice type…
-            </option>
-            {OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
+          <div className="mt-4 space-y-2">
+            <label htmlFor={selectId} className={UI.label}>
+              Notice type
+            </label>
+            <select
+              id={selectId}
+              ref={selectRef}
+              className={`${UI.input} w-full bg-white text-[#0f172a] focus:ring-offset-transparent`}
+              value={licensingValue}
+              onChange={handleSelectChange}
+              aria-invalid={hasError}
+              aria-describedby={describedBy || undefined}
+              data-testid="select-notice-type"
+            >
+              <option value="" disabled>
+                Select a notice type…
               </option>
-            ))}
-          </select>
-          {descriptor && (
-            <p id={helperId} className="text-sm text-brand-gray">
-              {descriptor}
-            </p>
-          )}
-          {error && (
-            <p id={errorId} className="text-sm text-red-600">
-              {error}
-            </p>
-          )}
-        </div>
-      </section>
+              {OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            {descriptor && (
+              <p id={helperId} className="text-sm text-brand-gray">
+                {descriptor}
+              </p>
+            )}
+            {hasError && (
+              <p id={errorId} className="text-sm text-red-600">
+                Select a notice type to continue.
+              </p>
+            )}
+          </div>
+          <div className="mt-6 flex justify-end">
+            <button
+              type="button"
+              className={`${UI.btnPrimary} ${!isValid ? 'cursor-not-allowed opacity-60' : ''}`}
+              onClick={handleContinue}
+              data-testid="btn-continue-step1"
+              aria-disabled={!isValid}
+            >
+              Continue
+            </button>
+          </div>
+        </section>
+        {/* CN:STEP1-END */}
+      </>
     );
   }
 );
 
 export default NoticeTypeStep;
-// CN:STEP1-END


### PR DESCRIPTION
## Summary
- gate the notice type step with inline validation and helper copy tied to the selected option
- replace the tooltip trigger with an accessible “i” button that can be suppressed by parent containers and closes on blur/Esc
- wire the upload flow to the updated notice type step so Step 1 persists the choice, syncs the query string, and only advances when valid

## Testing
- npm run test *(fails: vitest not installed before npm install)*
- npm install *(fails: npm registry returned 403 for dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68c963c32f688330a1ffbc958dd15734