### PR TITLE
feat: polish publish step one guidance

### DIFF
--- a/src/components/publish/ProgressBar.tsx
+++ b/src/components/publish/ProgressBar.tsx
@@ -11,16 +11,29 @@ export default function ProgressBar({ step, totalSteps = 3, labels }: Props) {
   const steps = items.length;
   return (
     <div className="mb-4" data-testid="progress-bar">
+      {/* CN:STEP1-START */}
       <div className="flex items-center justify-between">
         {items.map((l, i) => {
           const idx = i + 1 as 1 | 2 | 3 | 4;
           const state = idx < step ? 'completed' : idx === step ? 'current' : 'upcoming';
-          const active = state === 'current';
+          const isCurrent = state === 'current';
+          const isCompleted = state === 'completed';
+          const dotClass = [
+            UI.stepDotBase,
+            'transition-all duration-200 ease-[cubic-bezier(.2,.8,.2,1)]',
+            isCurrent || isCompleted ? 'border-transparent bg-[#2563EB] text-white shadow-[0_8px_20px_rgba(37,99,235,0.35)]' : 'border-white/40 bg-white/10 text-white/60',
+            isCurrent ? 'scale-105' : isCompleted ? 'opacity-100' : 'opacity-60',
+          ].join(' ');
+          const labelClass = `text-sm ${isCurrent ? 'font-semibold text-white' : isCompleted ? 'text-white/90' : 'text-white/60'}`;
           return (
             <div key={i} className="flex items-center gap-x-3 md:gap-x-4">
-              <div className={`${UI.stepDotBase} ${active ? UI.stepDotActive : ''}`} aria-current={active} aria-label={`Step ${idx}`} />
+              <div
+                className={dotClass}
+                aria-current={isCurrent ? 'step' : undefined}
+                aria-label={`Step ${idx}`}
+              />
               <span
-                className={`text-sm ${active ? 'text-white/90 font-medium' : 'text-white/90'}`}
+                className={labelClass}
                 data-testid={`progress-label-${i}`}
                 data-state={state}
               >
@@ -30,6 +43,7 @@ export default function ProgressBar({ step, totalSteps = 3, labels }: Props) {
           );
         })}
       </div>
+      {/* CN:STEP1-END */}
       {/* Track under the dots */}
       <div className="mt-3 relative h-1">
         <div className={`absolute inset-0 ${UI.stepperTrack}`} />

--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -327,14 +327,41 @@ export default function UploadNoticeFlow() {
           )}
         </main>
         <aside className="md:col-span-1 md:sticky md:top-[var(--headerH)] space-y-4">
-          <PreviewCard text={text} />
-          <ComplianceCard items={runMandatoryChecks(draft)} onFix={handleFix} />
-          <KeyDatesCard
-            applicationDate={draft.applicationDate}
-            representationDeadline={draft.repsDeadline || ''}
-            consultationDays={28}
-          />
-          <CostCard cost={0} canSubmit={canContinue && step === 3} />
+          {/* CN:STEP1-START */}
+          {step === 1 ? (
+            <>
+              <div className={`${UI.card} p-4 md:p-5`}>
+                <h3 className={UI.cardHeader}>Preview</h3>
+                <p className="mt-1 text-sm text-slate-600">
+                  Preview appears after you upload or complete details in Step 2.
+                </p>
+              </div>
+              <div className={`${UI.card} p-4 md:p-5`}>
+                <h3 className={UI.cardHeader}>Compliance checklist</h3>
+                <p className="mt-1 text-sm text-slate-600">
+                  We’ll run compliance checks once details are entered.
+                </p>
+              </div>
+              <div className={`${UI.card} p-4 md:p-5`}>
+                <h3 className={UI.cardHeader}>Key dates</h3>
+                <p className="mt-1 text-sm text-slate-600">
+                  Dates will be calculated after you set your submission date in Step 2.
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <PreviewCard text={text} />
+              <ComplianceCard items={runMandatoryChecks(draft)} onFix={handleFix} />
+              <KeyDatesCard
+                applicationDate={draft.applicationDate}
+                representationDeadline={draft.repsDeadline || ''}
+                consultationDays={28}
+              />
+              <CostCard cost={0} canSubmit={canContinue && step === 3} />
+            </>
+          )}
+          {/* CN:STEP1-END */}
         </aside>
       </div>
     </div>

--- a/src/components/publish/sections/NoticeTypeStep.tsx
+++ b/src/components/publish/sections/NoticeTypeStep.tsx
@@ -86,6 +86,11 @@ function useTooltipControls() {
     return () => document.removeEventListener('focusin', handleFocusIn);
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    panelRef.current?.focus();
+  }, [open]);
+
   return { open, setOpen, panelRef, buttonRef };
 }
 
@@ -102,13 +107,22 @@ const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
     const licensingValue = isLicensingNoticeType(value) ? value : '';
     const isValid = licensingValue !== '';
 
-    const descriptor = useMemo(() => {
-      if (!licensingValue) return undefined;
-      return OPTIONS.find((option) => option.value === licensingValue)?.descriptor;
+    const helperText = useMemo(() => {
+      if (!licensingValue) return 'Pick the exact category to proceed.';
+      if (licensingValue === 'premises') {
+        return 'Alcohol/regulated entertainment & late-night refreshment.';
+      }
+      if (licensingValue === 'variation') {
+        return 'Change to existing licence (hours, conditions, layout, etc.).';
+      }
+      if (licensingValue === 'review') {
+        return 'Application to review an existing licence.';
+      }
+      return 'Pick the exact category to proceed.';
     }, [licensingValue]);
 
     const hasError = touched && !isValid;
-    const describedBy = [descriptor ? helperId : undefined, hasError ? errorId : undefined]
+    const describedBy = [helperId, hasError ? errorId : undefined]
       .filter(Boolean)
       .join(' ');
 
@@ -142,7 +156,7 @@ const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
     return (
       <>
         {/* CN:STEP1-START */}
-        <section className={UI.card + ' p-5 md:p-6'} data-testid="notice-type-step">
+        <section className={`${UI.card} p-5 md:p-6 scroll-mt-24`} data-testid="notice-type-step">
           <div className="flex items-center justify-between">
             <h2 className="text-base font-semibold">Confirm Notice Type</h2>
             {!suppressInlineHelp && (
@@ -151,6 +165,7 @@ const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
                   type="button"
                   ref={buttonRef}
                   aria-label="Read more about notice types"
+                  aria-haspopup="dialog"
                   aria-expanded={open}
                   aria-controls={tooltipId}
                   onClick={() => setOpen((prev) => !prev)}
@@ -165,11 +180,11 @@ const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
                     id={tooltipId}
                     role="tooltip"
                     ref={panelRef}
-                    tabIndex={-1}
+                    tabIndex={0}
                     className="absolute right-0 z-20 mt-2 w-72 max-w-xs rounded-xl border border-brand-blue/20 bg-white p-4 text-sm text-brand-navy shadow-[0_10px_28px_rgba(25,38,80,0.14)]"
                   >
                     <p>
-                      Choose the exact Licensing Act 2003 category. This controls the required wording and deadlines later.
+                      Pick the exact Licensing Act 2003 category. It controls required wording and deadlines later.
                     </p>
                     <a
                       href="/docs/licensing-act-2003/premises-notices"
@@ -193,7 +208,7 @@ const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
               value={licensingValue}
               onChange={handleSelectChange}
               aria-invalid={hasError}
-              aria-describedby={describedBy || undefined}
+              aria-describedby={describedBy}
               data-testid="select-notice-type"
             >
               <option value="" disabled>
@@ -205,11 +220,11 @@ const NoticeTypeStep = forwardRef<HTMLSelectElement, Props>(
                 </option>
               ))}
             </select>
-            {descriptor && (
-              <p id={helperId} className="text-sm text-brand-gray">
-                {descriptor}
-              </p>
-            )}
+            <p id={helperId} className="text-sm text-brand-gray">
+              {/* CN:STEP1-START */}
+              {helperText}
+              {/* CN:STEP1-END */}
+            </p>
             {hasError && (
               <p id={errorId} className="text-sm text-red-600">
                 Select a notice type to continue.


### PR DESCRIPTION
## Summary
- emphasise the current step in the publish progress bar with a filled primary dot and bold label for clarity
- gate the publish right rail on Step 1 with lightweight placeholder cards while hiding the submit action
- refine the notice type step helper copy, tooltip accessibility and scroll anchoring for better guidance

## Testing
- npm run lint *(fails: missing @eslint/js dependency because packages could not be installed in the environment)*
- npm run test *(fails: vitest binary unavailable because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c96ee2a8888330af35236fa26b8acf