### PR TITLE
feat: restructure step 2 form and auto-calc deadlines

### DIFF
--- a/src/components/publish/RightRail/KeyDatesCard.tsx
+++ b/src/components/publish/RightRail/KeyDatesCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as UI from '@/styles/ui';
+import { calculateRepresentationDeadline, formatLicensingDate } from '@/lib/dates/licensing';
 
 export default function KeyDatesCard({
   applicationDate,
@@ -9,9 +10,20 @@ export default function KeyDatesCard({
   representationDeadline: string;
   consultationDays: number;
 }) {
+  /* CN:STEP2-START */
+  const hasSubmission = !!applicationDate;
+  const submissionDisplay = hasSubmission ? formatLicensingDate(applicationDate) : '';
+  const derivedDeadline = React.useMemo(() => {
+    if (representationDeadline) return representationDeadline;
+    if (!applicationDate) return '';
+    const computed = calculateRepresentationDeadline(applicationDate);
+    return Number.isNaN(computed.getTime()) ? '' : computed.toISOString();
+  }, [applicationDate, representationDeadline]);
+  const deadlineDisplay = derivedDeadline ? formatLicensingDate(derivedDeadline) : '—';
+
   return (
     <div className={`${UI.card} ${UI.cardHover} p-4 md:p-5`} aria-label="Key dates">
-      <div className="flex items-start justify-between mb-2">
+      <div className="flex items-start justify-between mb-3">
         <h3 className="text-sm font-semibold text-blue-900">Key dates</h3>
         <button
           type="button"
@@ -33,8 +45,26 @@ export default function KeyDatesCard({
           </svg>
         </button>
       </div>
-      <div className="text-sm text-[#192650]">Application date: {applicationDate || '—'}</div>
-      <div className="text-sm mt-1 text-[#192650]">Representation deadline (per Licensing Act 2003): {representationDeadline}</div>
+      {hasSubmission ? (
+        <dl className="space-y-3 text-sm text-[#192650]">
+          <div className="flex items-start justify-between gap-4">
+            <dt className="font-medium">Application date</dt>
+            <dd>{submissionDisplay}</dd>
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <dt className="font-medium">Representation deadline</dt>
+            <dd className="text-right">
+              <div>{deadlineDisplay}</div>
+              <span className="block text-xs text-slate-500">Licensing Act 2003</span>
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <p className="text-sm text-slate-600">
+          Dates will be calculated after you set your submission date in Step 2.
+        </p>
+      )}
     </div>
   );
+  /* CN:STEP2-END */
 }

--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -5,16 +5,29 @@ import PreviewCard from '@/components/publish/RightRail/PreviewCard';
 import ComplianceCard from '@/components/publish/RightRail/ComplianceCard';
 import KeyDatesCard from '@/components/publish/RightRail/KeyDatesCard';
 import CostCard from '@/components/publish/RightRail/CostCard';
+import AddressAutocomplete, { type AddressOption } from '@/components/AddressAutocomplete';
 import { lookupCouncilByPostcode } from '@/lib/councilLookup';
 import { runMandatoryChecks, calcRepsDeadline } from '@/lib/licensing/checks';
+/* CN:STEP2-START */
+import { calculateRepresentationDeadline, formatLicensingDate } from '@/lib/dates/licensing';
+/* CN:STEP2-END */
 import * as UI from '@/styles/ui';
 import type { NoticeDraft, NoticeType } from '@/types/notice';
 import { sha256Hex } from '@/lib/hash';
-import ApplicantCouncilSection from './sections/ApplicantCouncilSection';
-import ApplicationBasicsSection from './sections/ApplicationBasicsSection';
 /* CN:STEP1-START */
 import NoticeTypeStep, { isLicensingNoticeType } from './sections/NoticeTypeStep';
 /* CN:STEP1-END */
+
+/* CN:STEP2-START */
+type NoticeFieldRefs = {
+  applicant?: React.RefObject<HTMLInputElement>;
+  premisesAddress?: React.RefObject<HTMLInputElement | HTMLTextAreaElement>;
+  councilName?: React.RefObject<HTMLInputElement>;
+  councilEmail?: React.RefObject<HTMLInputElement>;
+  councilAddress?: React.RefObject<HTMLInputElement | HTMLTextAreaElement>;
+  applicationDate?: React.RefObject<HTMLInputElement>;
+};
+/* CN:STEP2-END */
 
 export default function UploadNoticeFlow() {
   const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
@@ -25,6 +38,9 @@ export default function UploadNoticeFlow() {
     noticeType: undefined,
     applicantName: '',
     applicantEmail: '',
+    /* CN:STEP2-START */
+    urn: '',
+    /* CN:STEP2-END */
     premisesAddress: '',
     postcode: '',
     councilName: '',
@@ -37,25 +53,62 @@ export default function UploadNoticeFlow() {
   const [confirmA, setConfirmA] = useState(false);
   const [confirmB, setConfirmB] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const refs = {
+  const refs: NoticeFieldRefs = {
     applicant: React.useRef<HTMLInputElement>(null),
-    premisesAddress: React.useRef<HTMLInputElement>(null),
+    /* CN:STEP2-START */
+    premisesAddress: React.useRef<HTMLInputElement | HTMLTextAreaElement>(null),
     councilName: React.useRef<HTMLInputElement>(null),
     councilEmail: React.useRef<HTMLInputElement>(null),
-    councilAddress: React.useRef<HTMLInputElement>(null),
+    councilAddress: React.useRef<HTMLInputElement | HTMLTextAreaElement>(null),
     applicationDate: React.useRef<HTMLInputElement>(null),
-  } as const;
+    /* CN:STEP2-END */
+  };
+  /* CN:STEP2-START */
   const requiredOk =
     draft.applicantName.trim() &&
+    draft.premisesAddress.trim() &&
     draft.postcode.trim() &&
     draft.councilName.trim() &&
     draft.councilEmail.trim() &&
-    draft.councilAddress.trim() &&
     draft.applicationDate.trim();
+  /* CN:STEP2-END */
   const canContinue = requiredOk && confirmA && confirmB;
 
   const handleBack = () => setStep((prev) => Math.max(1, (prev as number) - 1) as 1 | 2 | 3 | 4);
   const handleNext = () => setStep((prev) => Math.min(4, (prev as number) + 1) as 1 | 2 | 3 | 4);
+
+  /* CN:STEP2-START */
+  const makeReference = React.useCallback(() => {
+    const stamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const random = Math.random().toString(36).slice(2, 6).toUpperCase();
+    return `CN-${stamp}-${random}`;
+  }, []);
+
+  const hasAutoUrn = React.useRef(false);
+
+  const updateDraft = React.useCallback(
+    (patch: Partial<NoticeDraft>, options?: { ensureUrn?: boolean }) => {
+      setDraft((prev) => {
+        const next = { ...prev, ...patch };
+        if (typeof patch.urn !== 'undefined') {
+          hasAutoUrn.current = hasAutoUrn.current || !!patch.urn;
+        }
+        if (
+          options?.ensureUrn &&
+          !prev.urn &&
+          !patch.urn &&
+          !hasAutoUrn.current
+        ) {
+          const generated = makeReference();
+          hasAutoUrn.current = true;
+          next.urn = generated;
+        }
+        return next;
+      });
+    },
+    [makeReference]
+  );
+  /* CN:STEP2-END */
 
   /* CN:STEP1-START */
   // On mount: read ?type= and set draft.noticeType if valid
@@ -84,19 +137,26 @@ export default function UploadNoticeFlow() {
 
   // Keep reps deadline in sync with application date (28 days)
   useEffect(() => {
-    if (!draft.applicationDate) return;
+    /* CN:STEP2-START */
+    if (!draft.applicationDate) {
+      if (draft.repsDeadline) {
+        setDraft((d) => ({ ...d, repsDeadline: '' }));
+      }
+      return;
+    }
     const expected = calcRepsDeadline(draft.applicationDate);
-    if (draft.repsDeadline !== expected) {
+    if (expected && draft.repsDeadline !== expected) {
       setDraft((d) => ({ ...d, repsDeadline: expected }));
     }
-  }, [draft.applicationDate]);
+    /* CN:STEP2-END */
+  }, [draft.applicationDate, draft.repsDeadline]);
 
   const toErrorKey = (target: string) => (target === 'premises-address' ? 'premisesAddress' : target);
   const handleFix = (target?: string) => {
     if (!target) return;
     // When on Step 2, prefer focusing inline Required details inputs via refs
     if (step === 2) {
-      const map: Record<string, React.RefObject<HTMLInputElement> | undefined> = {
+      const map: Record<string, React.RefObject<HTMLInputElement | HTMLTextAreaElement> | undefined> = {
         applicant: refs.applicant,
         applicantName: refs.applicant,
         addr: refs.premisesAddress,
@@ -157,57 +217,39 @@ export default function UploadNoticeFlow() {
                 onMeta={(m) => setDraft((d) => ({ ...d, originalFileMeta: m }))}
               />
               <section className={UI.section} data-testid="required-inline">
-                <div className="flex items-center justify-between">
-                  <h3 className="font-medium text-brand-navy">Required details (Licensing Act 2003)</h3>
+                {/* CN:STEP2-START */}
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="font-medium text-brand-navy">Licensing Act 2003 details</h3>
+                    <p className="mt-1 text-xs text-slate-600">Complete each section to continue.</p>
+                  </div>
                   <span
                     className="inline-block rounded bg-brand-lilac text-brand-navy ring-1 ring-brand-blue/20 px-2 py-0.5 text-xs"
                     data-testid="required-inline-counter"
                   >
                     {(() => {
-                      const c = [
+                      const checks = [
                         !!draft.applicantName?.trim(),
+                        !!draft.premisesAddress?.trim(),
                         !!draft.postcode?.trim(),
                         !!draft.councilName?.trim(),
                         !!draft.councilEmail?.trim(),
-                        !!draft.councilAddress?.trim(),
                         !!draft.applicationDate?.trim(),
                       ].filter(Boolean).length;
-                      return `Required: ${c}/6`;
+                      return `Required: ${checks}/6`;
                     })()}
                   </span>
                 </div>
-                <ApplicantCouncilSection
+                <NoticeDetailsSections
                   draft={draft}
-                  onChange={(p) => setDraft((d) => ({ ...d, ...p }))}
+                  onChange={updateDraft}
                   refs={refs}
+                  confirmA={confirmA}
+                  confirmB={confirmB}
+                  onConfirmAChange={setConfirmA}
+                  onConfirmBChange={setConfirmB}
                 />
-                <ApplicationBasicsSection
-                  draft={draft}
-                  onChange={(p) => setDraft((d) => ({ ...d, ...p }))}
-                  refs={refs}
-                />
-                <div className="mt-4 flex items-center gap-2">
-                  <input
-                    id="confirm-a"
-                    type="checkbox"
-                    checked={confirmA}
-                    onChange={(e) => setConfirmA(e.target.checked)}
-                  />
-                  <label htmlFor="confirm-a" className="text-sm">
-                    I confirm the above text is a true and accurate copy of the notice published/displayed.
-                  </label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="confirm-b"
-                    type="checkbox"
-                    checked={confirmB}
-                    onChange={(e) => setConfirmB(e.target.checked)}
-                  />
-                  <label htmlFor="confirm-b" className="text-sm">
-                    I understand that supplying false information is an offence.
-                  </label>
-                </div>
+                {/* CN:STEP2-END */}
               </section>
             </>
           )}
@@ -226,38 +268,17 @@ export default function UploadNoticeFlow() {
                     }}
                   />
                 </div>
-                <ApplicantCouncilSection
+                {/* CN:STEP2-START */}
+                <NoticeDetailsSections
                   draft={draft}
-                  onChange={(p) => setDraft((d) => ({ ...d, ...p }))}
+                  onChange={updateDraft}
                   refs={refs}
+                  confirmA={confirmA}
+                  confirmB={confirmB}
+                  onConfirmAChange={setConfirmA}
+                  onConfirmBChange={setConfirmB}
                 />
-                <ApplicationBasicsSection
-                  draft={draft}
-                  onChange={(p) => setDraft((d) => ({ ...d, ...p }))}
-                  refs={refs}
-                />
-                <div className="mt-4 flex items-center gap-2">
-                  <input
-                    id="confirm-a"
-                    type="checkbox"
-                    checked={confirmA}
-                    onChange={(e) => setConfirmA(e.target.checked)}
-                  />
-                  <label htmlFor="confirm-a" className="text-sm">
-                    I confirm the above text is a true and accurate copy of the notice published/displayed.
-                  </label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="confirm-b"
-                    type="checkbox"
-                    checked={confirmB}
-                    onChange={(e) => setConfirmB(e.target.checked)}
-                  />
-                  <label htmlFor="confirm-b" className="text-sm">
-                    I understand that supplying false information is an offence.
-                  </label>
-                </div>
+                {/* CN:STEP2-END */}
                 <div className="mt-4 flex items-center justify-between">
                   <button
                     className={UI.btnSecondary}
@@ -319,7 +340,7 @@ export default function UploadNoticeFlow() {
                     data-testid="link-skip-ocr"
                     onClick={() => setStep(3)}
                   >
-                    Skip OCR for now
+                    {/* CN:STEP2-START */}Enter details manually{/* CN:STEP2-END */}
                   </button>
                 </div>
               </div>
@@ -367,3 +388,261 @@ export default function UploadNoticeFlow() {
     </div>
   );
 }
+
+/* CN:STEP2-START */
+type NoticeDetailsSectionsProps = {
+  draft: NoticeDraft;
+  onChange: (patch: Partial<NoticeDraft>, options?: { ensureUrn?: boolean }) => void;
+  refs: NoticeFieldRefs;
+  confirmA: boolean;
+  confirmB: boolean;
+  onConfirmAChange: (next: boolean) => void;
+  onConfirmBChange: (next: boolean) => void;
+};
+
+function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
+  const { draft, onChange, refs, confirmA, confirmB, onConfirmAChange, onConfirmBChange } = props;
+  const manualAddressHelpId = React.useId();
+  const referenceHelpId = React.useId();
+  const deadlineHelpId = React.useId();
+  const lookedUpEmail = React.useRef('');
+  const lookedUpName = React.useRef('');
+  const lookedUpAddress = React.useRef('');
+
+  const representationIso = React.useMemo(() => {
+    if (draft.repsDeadline) return draft.repsDeadline;
+    if (!draft.applicationDate) return '';
+    const computed = calculateRepresentationDeadline(draft.applicationDate);
+    return Number.isNaN(computed.getTime()) ? '' : computed.toISOString();
+  }, [draft.applicationDate, draft.repsDeadline]);
+
+  const representationDisplay = representationIso ? formatLicensingDate(representationIso) : '—';
+
+  const handleAddressSelect = (option: AddressOption) => {
+    const composed = option.label || [option.line1, option.city ?? option.town, option.postcode].filter(Boolean).join(', ');
+    const postcode = option.postcode || '';
+    onChange({ premisesAddress: composed, postcode }, { ensureUrn: true });
+    if (!postcode) return;
+    const res = lookupCouncilByPostcode(postcode);
+    if (!res) return;
+    lookedUpEmail.current = res.councilEmail || '';
+    lookedUpName.current = res.councilName || '';
+    lookedUpAddress.current = res.councilAddress || '';
+    onChange(
+      {
+        councilName: res.councilName || draft.councilName,
+        councilEmail: res.councilEmail || draft.councilEmail,
+        councilAddress: res.councilAddress || draft.councilAddress,
+      },
+      { ensureUrn: true }
+    );
+  };
+
+  const handleSubmissionDate = (value: string) => {
+    if (!value) {
+      onChange({ applicationDate: '', repsDeadline: '' }, { ensureUrn: true });
+      return;
+    }
+    const computed = calculateRepresentationDeadline(value);
+    const iso = Number.isNaN(computed.getTime()) ? '' : computed.toISOString();
+    onChange({ applicationDate: value, repsDeadline: iso }, { ensureUrn: true });
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h3 className="text-sm font-semibold text-brand-navy">Applicant details</h3>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="applicantName" className={UI.label}>
+              Applicant name<span className="text-rose-600">*</span>
+            </label>
+            <input
+              id="applicantName"
+              ref={refs.applicant}
+              className={UI.input}
+              data-testid="input-applicant-name"
+              value={draft.applicantName}
+              onChange={(e) => onChange({ applicantName: e.target.value }, { ensureUrn: true })}
+            />
+          </div>
+          <div>
+            <label htmlFor="urn" className={UI.label}>
+              URN / Reference <span className="text-xs font-normal text-slate-500">(optional)</span>
+            </label>
+            <input
+              id="urn"
+              className={UI.input}
+              value={draft.urn || ''}
+              onChange={(e) => onChange({ urn: e.target.value })}
+              aria-describedby={referenceHelpId}
+            />
+            <p id={referenceHelpId} className="mt-1 text-xs text-slate-600">
+              Auto-generated when you start editing; update if your authority provided a specific reference.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-slate-200/80 pt-6">
+        <h3 className="text-sm font-semibold text-brand-navy">Premises &amp; Council details</h3>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <div id="premises-address" className="md:col-span-2">
+            <AddressAutocomplete
+              label="Premises address (search)"
+              onSelect={handleAddressSelect}
+              inputTestId="input-premises-address"
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label htmlFor="premisesAddressManual" className={UI.label}>
+              Premises address<span className="text-rose-600">*</span>
+            </label>
+            <textarea
+              id="premisesAddressManual"
+              ref={refs.premisesAddress as React.RefObject<HTMLTextAreaElement>}
+              className={`${UI.input} min-h-[96px]`}
+              value={draft.premisesAddress}
+              onChange={(e) => onChange({ premisesAddress: e.target.value }, { ensureUrn: true })}
+              aria-describedby={manualAddressHelpId}
+            />
+            <p id={manualAddressHelpId} className="mt-1 text-xs text-slate-600">
+              Search above, then adjust the address exactly as it should appear on the notice.
+            </p>
+          </div>
+          <div>
+            <label htmlFor="postcode" className={UI.label}>
+              Postcode<span className="text-rose-600">*</span>
+            </label>
+            <input
+              id="postcode"
+              className={UI.input}
+              value={draft.postcode}
+              onChange={(e) => onChange({ postcode: e.target.value }, { ensureUrn: true })}
+            />
+          </div>
+          <div>
+            <label htmlFor="councilName" className={UI.label}>
+              Council name<span className="text-rose-600">*</span>
+            </label>
+            <input
+              id="councilName"
+              ref={refs.councilName}
+              className={UI.input}
+              data-testid="input-council-name"
+              value={draft.councilName}
+              onChange={(e) => onChange({ councilName: e.target.value }, { ensureUrn: true })}
+            />
+            {lookedUpName.current && draft.councilName && draft.councilName !== lookedUpName.current && (
+              <span className="mt-1 inline-block rounded bg-amber-50 px-2 py-0.5 text-xs text-amber-700">
+                Value differs from council directory
+              </span>
+            )}
+          </div>
+          <div>
+            <label htmlFor="councilEmail" className={UI.label}>
+              Council email<span className="text-rose-600">*</span>
+            </label>
+            <input
+              id="councilEmail"
+              type="email"
+              ref={refs.councilEmail}
+              className={UI.input}
+              data-testid="input-council-email"
+              value={draft.councilEmail}
+              onChange={(e) => onChange({ councilEmail: e.target.value }, { ensureUrn: true })}
+            />
+            {lookedUpEmail.current && draft.councilEmail && draft.councilEmail !== lookedUpEmail.current && (
+              <span className="mt-1 inline-block rounded bg-amber-50 px-2 py-0.5 text-xs text-amber-700">
+                Value differs from council directory
+              </span>
+            )}
+          </div>
+          <div className="md:col-span-2">
+            <label htmlFor="councilAddress" className={UI.label}>
+              Council address <span className="text-xs font-normal text-slate-500">(optional)</span>
+            </label>
+            <textarea
+              id="councilAddress"
+              ref={refs.councilAddress as React.RefObject<HTMLTextAreaElement>}
+              className={`${UI.input} min-h-[96px]`}
+              data-testid="input-council-address"
+              value={draft.councilAddress}
+              onChange={(e) => onChange({ councilAddress: e.target.value }, { ensureUrn: true })}
+            />
+            {lookedUpAddress.current && draft.councilAddress && draft.councilAddress !== lookedUpAddress.current && (
+              <span className="mt-1 inline-block rounded bg-amber-50 px-2 py-0.5 text-xs text-amber-700">
+                Value differs from council directory
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-slate-200/80 pt-6">
+        <h3 className="text-sm font-semibold text-brand-navy">Dates &amp; declarations</h3>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="applicationDate" className={UI.label}>
+              Date of submission<span className="text-rose-600">*</span>
+            </label>
+            <input
+              id="applicationDate"
+              type="date"
+              ref={refs.applicationDate}
+              className={UI.input}
+              data-testid="input-application-date"
+              value={draft.applicationDate}
+              onChange={(e) => handleSubmissionDate(e.target.value)}
+            />
+          </div>
+          <div>
+            <label htmlFor="representationDeadline" className={UI.label}>
+              Representation deadline
+            </label>
+            <input
+              id="representationDeadline"
+              className={`${UI.input} bg-slate-50 text-slate-700`}
+              value={representationDisplay}
+              readOnly
+              aria-readonly="true"
+              aria-describedby={deadlineHelpId}
+              data-testid="input-representation-deadline"
+              aria-live="polite"
+            />
+            <p id={deadlineHelpId} className="mt-1 text-xs text-slate-600">
+              Auto-calculated as 28 calendar days after the submission date.
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 space-y-3">
+          <div className="flex items-start gap-3">
+            <input
+              id="confirm-a"
+              type="checkbox"
+              className="mt-1 h-4 w-4 rounded border-slate-300 text-[#2563EB] focus:ring-[#2563EB]"
+              checked={confirmA}
+              onChange={(e) => onConfirmAChange(e.target.checked)}
+            />
+            <label htmlFor="confirm-a" className="text-sm leading-5 text-slate-800">
+              I confirm the above text is a true and accurate copy of the notice published/displayed.
+            </label>
+          </div>
+          <div className="flex items-start gap-3">
+            <input
+              id="confirm-b"
+              type="checkbox"
+              className="mt-1 h-4 w-4 rounded border-slate-300 text-[#2563EB] focus:ring-[#2563EB]"
+              checked={confirmB}
+              onChange={(e) => onConfirmBChange(e.target.checked)}
+            />
+            <label htmlFor="confirm-b" className="text-sm leading-5 text-slate-800">
+              I understand that supplying false information is an offence.
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+/* CN:STEP2-END */

--- a/src/lib/dates/licensing.ts
+++ b/src/lib/dates/licensing.ts
@@ -1,0 +1,20 @@
+/* CN:STEP2-START */
+export function calculateRepresentationDeadline(input: Date | string): Date {
+  const d = new Date(input);
+  d.setHours(12, 0, 0, 0);
+  const out = new Date(d);
+  out.setDate(out.getDate() + 28);
+  out.setHours(23, 59, 59, 999);
+  return out;
+}
+
+export function formatLicensingDate(
+  input?: Date | string | null,
+  locale: string = 'en-GB'
+): string {
+  if (!input) return '';
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(locale, { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+/* CN:STEP2-END */

--- a/src/lib/licensing/checks.test.ts
+++ b/src/lib/licensing/checks.test.ts
@@ -4,7 +4,9 @@ import { NoticeDraft } from '@/types/notice';
 
 describe('calcRepsDeadline', () => {
   it('adds 28 days', () => {
-    expect(calcRepsDeadline('2024-01-01')).toBe('2024-01-29');
+    /* CN:STEP2-START */
+    expect(calcRepsDeadline('2024-01-01')).toBe('2024-01-29T23:59:59.999Z');
+    /* CN:STEP2-END */
   });
 });
 
@@ -30,7 +32,9 @@ describe('runMandatoryChecks', () => {
       blueNoticeUploads: [],
       status: 'Draft',
       applicationDate: '2024-01-01',
-      repsDeadline: '2024-01-29',
+      /* CN:STEP2-START */
+      repsDeadline: '2024-01-29T23:59:59.999Z',
+      /* CN:STEP2-END */
     };
     const res = runMandatoryChecks(draft);
     const item = res.find((r) => r.id === 'repsDeadline');

--- a/src/lib/licensing/checks.ts
+++ b/src/lib/licensing/checks.ts
@@ -1,4 +1,7 @@
 import { NoticeDraft } from '@/types/notice';
+/* CN:STEP2-START */
+import { calculateRepresentationDeadline } from '@/lib/dates/licensing';
+/* CN:STEP2-END */
 
 export type ComplianceItem = {
   id: string;
@@ -10,11 +13,13 @@ export type ComplianceItem = {
 };
 export type ComplianceResult = ComplianceItem[];
 
+/* CN:STEP2-START */
 export function calcRepsDeadline(date: string): string {
-  const d = new Date(date);
-  d.setDate(d.getDate() + 28);
-  return d.toISOString().slice(0, 10);
+  if (!date) return '';
+  const deadline = calculateRepresentationDeadline(date);
+  return Number.isNaN(deadline.getTime()) ? '' : deadline.toISOString();
 }
+/* CN:STEP2-END */
 
 export function runMandatoryChecks(draft: NoticeDraft): ComplianceResult {
   const items: ComplianceResult = [];
@@ -33,13 +38,20 @@ export function runMandatoryChecks(draft: NoticeDraft): ComplianceResult {
   push('councilAddress', !!draft.councilAddress?.trim(), 'Council address present', 'councilAddress');
   push('applicationDate', !!draft.applicationDate?.trim(), 'Application date present', 'applicationDate');
   if (draft.repsDeadline) {
+    /* CN:STEP2-START */
     const expected = calcRepsDeadline(draft.applicationDate);
+    const normalize = (value: string) => {
+      if (!value) return '';
+      const d = new Date(value.includes('T') ? value : `${value}T00:00:00`);
+      return Number.isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10);
+    };
     push(
       'repsDeadline',
-      draft.repsDeadline === expected,
+      normalize(draft.repsDeadline) === normalize(expected),
       'Representation deadline = submission date + 28 days',
       'applicationDate'
     );
+    /* CN:STEP2-END */
   } else {
     push(
       'repsDeadline',

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -23,6 +23,9 @@ export type NoticeDraft = {
   applicantName: string;
   applicantEmail: string;
   applicantPhone?: string;
+  /* CN:STEP2-START */
+  urn?: string;
+  /* CN:STEP2-END */
   premisesName?: string;
   premisesAddress: string;
   postcode: string;


### PR DESCRIPTION
## Summary
- regroup Step 2 licensing fields into applicant, premises/council, and dates sections with auto-generated URN support
- derive 28-day representation deadlines via new licensing date utility and surface them in the form and key dates card
- keep notices in sync by normalising deadline storage and updating compliance checks/tests

## Testing
- npm test *(fails: vitest binary unavailable before dependencies could be installed due to registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c9797247688330a203950e6fea41ff