### PR TITLE
feat: licensing notice structured preview controls

### DIFF
--- a/src/components/publish/RightRail/KeyDatesCard.tsx
+++ b/src/components/publish/RightRail/KeyDatesCard.tsx
@@ -23,15 +23,10 @@ export default function KeyDatesCard({
 }) {
   /* CN:STEP2-START */
   const hasSubmission = !!applicationDate;
-  /* CN:FIX-START */
-  /* CN:STEP2-COMPLIANCE-UPGRADE-START */
-  /* CN:TEMPLATES-PREVIEW-START */
-  /* CN:LICENSING-TEMPLATES-START */
-  const submissionDisplay = hasSubmission ? formatDisplayDate(`${applicationDate}T00:00:00`) : '—';
-  /* CN:LICENSING-TEMPLATES-END */
-  /* CN:TEMPLATES-PREVIEW-END */
-  /* CN:STEP2-COMPLIANCE-UPGRADE-END */
-  /* CN:FIX-END */
+  // {/* CN:LICENSING-FINAL-START */}
+  const submissionIso = hasSubmission ? `${applicationDate}T00:00:00` : '';
+  const submissionDisplay = hasSubmission ? formatDisplayDate(submissionIso) : '—';
+  // {/* CN:LICENSING-FINAL-END */}
   const derivedDeadline = React.useMemo(() => {
     if (representationDeadline) return representationDeadline;
     if (!applicationDate) return '';
@@ -75,12 +70,20 @@ export default function KeyDatesCard({
       <dl className="space-y-3 text-sm text-[#192650]">
         <div className="flex items-start justify-between gap-4">
           <dt className="font-medium">Application date</dt>
-          <dd className="font-semibold">{submissionDisplay}</dd>
+          <dd className="font-semibold">
+            {/* CN:LICENSING-FINAL-START */}
+            {hasSubmission ? <time dateTime={submissionIso}>{submissionDisplay}</time> : submissionDisplay}
+            {/* CN:LICENSING-FINAL-END */}
+          </dd>
         </div>
         <div className="flex items-start justify-between gap-4">
           <dt className="font-medium">Representation deadline</dt>
           <dd className="text-right font-semibold">
-            <div>{deadlineDisplay}</div>
+            {/* CN:LICENSING-FINAL-START */}
+            <div>
+              {derivedDeadline ? <time dateTime={derivedDeadline}>{deadlineDisplay}</time> : deadlineDisplay}
+            </div>
+            {/* CN:LICENSING-FINAL-END */}
             <span className="block text-xs font-normal text-slate-500">Licensing Act 2003</span>
           </dd>
         </div>

--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import ProgressBar from './ProgressBar';
 import FileDropOCR from '@/components/upload/FileDropOCR';
-import PreviewCard from '@/components/publish/RightRail/PreviewCard';
+// {/* CN:LICENSING-FINAL-START */}
+import PreviewNotice from '@/features/publish/PreviewNotice';
 import ComplianceCard from '@/components/publish/RightRail/ComplianceCard';
 import KeyDatesCard from '@/components/publish/RightRail/KeyDatesCard';
 import CostCard from '@/components/publish/RightRail/CostCard';
@@ -13,7 +14,7 @@ import { calculateRepresentationDeadline } from '@/lib/dates/licensing';
 /* CN:STEP2-COMPLIANCE-START */
 import { formatDisplayDate } from '@/lib/format';
 import { getAuthorityByName, emailDomainMatchesAuthority } from '@/lib/authorities';
-import { buildPremisesNotice, buildVariationNotice, buildReviewNotice } from '@/features/publish/previewBuilders';
+// {/* CN:LICENSING-FINAL-END */}
 /* CN:STEP2-COMPLIANCE-END */
 /* CN:STEP2-END */
 import * as UI from '@/styles/ui';
@@ -49,7 +50,9 @@ function focusAndFlash(id: string) {
 
 export default function UploadNoticeFlow() {
   const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
-  const [text, setText] = useState('');
+  // {/* CN:LICENSING-FINAL-START */}
+  const [ocrText, setOcrText] = useState('');
+  // {/* CN:LICENSING-FINAL-END */}
   const [draft, setDraft] = useState<NoticeDraft>({
     id: '',
     createdAt: '',
@@ -92,11 +95,13 @@ export default function UploadNoticeFlow() {
   /* CN:STEP2-START */
   /* CN:TEMPLATES-PREVIEW-START */
   /* CN:LICENSING-TEMPLATES-START */
-  const hasNoticeText = text.trim().length > 0;
+  // {/* CN:LICENSING-FINAL-START */}
+  const hasOcrText = ocrText.trim().length > 0;
   const needsApplicationSummary =
-    !hasNoticeText && (draft.noticeType === 'premises' || draft.noticeType === 'variation');
-  const needsVariationSummary = !hasNoticeText && draft.noticeType === 'variation';
-  const needsReviewGrounds = !hasNoticeText && draft.noticeType === 'review';
+    !hasOcrText && (draft.noticeType === 'premises' || draft.noticeType === 'variation');
+  const needsVariationSummary = !hasOcrText && draft.noticeType === 'variation';
+  const needsReviewGrounds = !hasOcrText && draft.noticeType === 'review';
+  // {/* CN:LICENSING-FINAL-END */}
 
   const summariesOk =
     (!needsApplicationSummary || !!draft.applicationSummary?.trim()) &&
@@ -279,8 +284,10 @@ export default function UploadNoticeFlow() {
               <div className="[&>div]:p-6 [&>div]:md:p-6">
                 <FileDropOCR
                   onText={(t) => {
-                    setText(t);
+                    // {/* CN:LICENSING-FINAL-START */}
+                    setOcrText(t);
                     setDraft((d) => ({ ...d, finalText: t }));
+                    // {/* CN:LICENSING-FINAL-END */}
                   }}
                   onMeta={(m) => setDraft((d) => ({ ...d, originalFileMeta: m }))}
                 />
@@ -312,6 +319,9 @@ export default function UploadNoticeFlow() {
                   confirmB={confirmB}
                   onConfirmAChange={setConfirmA}
                   onConfirmBChange={setConfirmB}
+                  // {/* CN:LICENSING-FINAL-START */}
+                  hasOcrText={hasOcrText}
+                  // {/* CN:LICENSING-FINAL-END */}
                 />
                 {/* CN:STEP2-END */}
               </section>
@@ -325,11 +335,14 @@ export default function UploadNoticeFlow() {
                   <textarea
                     id="noticeText"
                     className={UI.input + ' h-40'}
-                    value={text}
+                    // {/* CN:LICENSING-FINAL-START */}
+                    value={draft.finalText || ''}
                     onChange={(e) => {
-                      setText(e.target.value);
-                      setDraft((d) => ({ ...d, finalText: e.target.value }));
+                      const value = e.target.value;
+                      setDraft((d) => ({ ...d, finalText: value }));
+                      setOcrText(value);
                     }}
+                    // {/* CN:LICENSING-FINAL-END */}
                   />
                 </div>
                 {/* CN:STEP2-START */}
@@ -341,6 +354,9 @@ export default function UploadNoticeFlow() {
                   confirmB={confirmB}
                   onConfirmAChange={setConfirmA}
                   onConfirmBChange={setConfirmB}
+                  // {/* CN:LICENSING-FINAL-START */}
+                  hasOcrText={hasOcrText}
+                  // {/* CN:LICENSING-FINAL-END */}
                 />
                 {/* CN:STEP2-END */}
                 <div className="mt-4 flex items-center justify-between">
@@ -396,7 +412,9 @@ export default function UploadNoticeFlow() {
                 </button>
                 <button
                   className={`${UI.btnPrimary} h-11 px-5 text-sm`}
-                  disabled={!text && !(requiredOk && confirmA && confirmB)}
+                  // {/* CN:LICENSING-FINAL-START */}
+                  disabled={!hasOcrText && !(requiredOk && confirmA && confirmB)}
+                  // {/* CN:LICENSING-FINAL-END */}
                   onClick={() => setStep(3)}
                   data-testid="btn-continue"
                 >
@@ -435,36 +453,23 @@ export default function UploadNoticeFlow() {
             <>
               {/* CN:STEP2-COMPLIANCE-START */}
               {(() => {
+                // {/* CN:LICENSING-FINAL-START */}
                 const auth = getAuthorityByName(draft.councilName);
-                const representationIso = draft.repsDeadline || (draft.applicationDate ? calculateRepresentationDeadline(draft.applicationDate).toISOString() : '');
-                const builderState = { ...draft, representationDeadline: representationIso };
-                /* CN:TEMPLATES-PREVIEW-START */
-                /* CN:LICENSING-TEMPLATES-START */
-                const built =
-                  draft.noticeType === 'variation'
-                    ? buildVariationNotice(builderState, auth)
-                    : draft.noticeType === 'review'
-                      ? buildReviewNotice(builderState, auth)
-                      : buildPremisesNotice(builderState, auth);
-                /* CN:LICENSING-TEMPLATES-END */
-                /* CN:TEMPLATES-PREVIEW-END */
-                const useText = (text ?? '').trim().length > 0 ? text : built;
-                /* CN:TEMPLATES-PREVIEW-START */
-                /* CN:LICENSING-TEMPLATES-START */
-                const summaryMissing =
-                  !hasNoticeText &&
-                  ((needsApplicationSummary && !draft.applicationSummary?.trim()) ||
-                    (needsVariationSummary && !draft.variationSummary?.trim()) ||
-                    (needsReviewGrounds && !draft.reviewGrounds?.trim()));
-                const showBanner = useText.includes('—') || summaryMissing;
-                /* CN:LICENSING-TEMPLATES-END */
-                /* CN:TEMPLATES-PREVIEW-END */
+                const representationIso =
+                  draft.repsDeadline || (draft.applicationDate ? calculateRepresentationDeadline(draft.applicationDate).toISOString() : '');
+                const builderState = { ...draft, representationDeadline: representationIso, ocrText };
                 return (
-                  <PreviewCard
-                    text={useText}
-                    statusMessage={showBanner ? 'Some fields are missing — the notice text will update as you complete the form.' : undefined}
+                  <PreviewNotice
+                    draft={builderState}
+                    authority={auth}
+                    ocrText={ocrText}
+                    onReplaceOcr={(next) => {
+                      setOcrText(next);
+                      setDraft((d) => ({ ...d, finalText: next }));
+                    }}
                   />
                 );
+                // {/* CN:LICENSING-FINAL-END */}
               })()}
               {/* CN:STEP2-COMPLIANCE-END */}
               <ComplianceCard items={runMandatoryChecks(draft)} onFix={handleFix} />
@@ -497,10 +502,13 @@ type NoticeDetailsSectionsProps = {
   confirmB: boolean;
   onConfirmAChange: (next: boolean) => void;
   onConfirmBChange: (next: boolean) => void;
+  // {/* CN:LICENSING-FINAL-START */}
+  hasOcrText: boolean;
+  // {/* CN:LICENSING-FINAL-END */}
 };
 
 function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
-  const { draft, onChange, refs, confirmA, confirmB, onConfirmAChange, onConfirmBChange } = props;
+  const { draft, onChange, refs, confirmA, confirmB, onConfirmAChange, onConfirmBChange, hasOcrText } = props;
   /* CN:STEP2-COMPLIANCE-START */
   const [ignoreDomainWarning, setIgnoreDomainWarning] = React.useState(false);
   /* CN:STEP2-COMPLIANCE-END */
@@ -533,11 +541,11 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
   /* CN:TEMPLATES-PREVIEW-START */
   /* CN:LICENSING-TEMPLATES-START */
   const authority = React.useMemo(() => getAuthorityByName(draft.councilName), [draft.councilName]);
-  const hasGeneratedNoticeText = !!draft.finalText?.trim();
-  const needsAppSummary =
-    !hasGeneratedNoticeText && (draft.noticeType === 'premises' || draft.noticeType === 'variation');
-  const needsVariationSummary = !hasGeneratedNoticeText && draft.noticeType === 'variation';
-  const needsReviewGrounds = !hasGeneratedNoticeText && draft.noticeType === 'review';
+  // {/* CN:LICENSING-FINAL-START */}
+  const needsAppSummary = !hasOcrText && (draft.noticeType === 'premises' || draft.noticeType === 'variation');
+  const needsVariationSummary = !hasOcrText && draft.noticeType === 'variation';
+  const needsReviewGrounds = !hasOcrText && draft.noticeType === 'review';
+  // {/* CN:LICENSING-FINAL-END */}
 
   const applicationSummaryError = needsAppSummary && !draft.applicationSummary?.trim();
   const variationSummaryError = needsVariationSummary && !draft.variationSummary?.trim();
@@ -561,10 +569,12 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
 
   const showDomainWarning = !!draft.councilEmail && !emailDomainMatchesAuthority(draft.councilEmail, authority);
   const canonicalAuthorityEmail = authority?.canonicalEmail || authority?.repsEmail || '';
-  const authorityRepsEmail = authority?.repsEmail || '';
+  // {/* CN:LICENSING-FINAL-START */}
+  const authorityRepsEmail = authority?.repsEmail || draft.councilEmail || '';
   const authorityRepsUrl = authority?.repsUrl || '';
-  const authorityPostalAddress = authority?.postalAddress || '';
+  const authorityPostalAddress = authority?.postalAddress || draft.councilAddress || '';
   const representationContactsIncomplete = !(authorityRepsEmail || authorityRepsUrl || authorityPostalAddress);
+  // {/* CN:LICENSING-FINAL-END */}
   /* CN:LICENSING-TEMPLATES-END */
   /* CN:TEMPLATES-PREVIEW-END */
 

--- a/src/components/upload/FileDropOCR.tsx
+++ b/src/components/upload/FileDropOCR.tsx
@@ -128,6 +128,9 @@ export default function FileDropOCR({ onText, onMeta }: FileDropOCRProps) {
         />
         <div className="text-sm text-slate-800">Drop PDF/DOCX/PNG/JPG (≤25MB) or click to upload</div>
         <div className="mt-2 text-xs text-slate-700">OCR will appear below; you can still edit everything.</div>
+        {/* CN:LICENSING-FINAL-START */}
+        <div className="mt-2 text-xs text-slate-500">You can edit your notice text in the next step if needed.</div>
+        {/* CN:LICENSING-FINAL-END */}
         <div className="sr-only" aria-live="polite">Status: {state}</div>
       </label>
 

--- a/src/features/publish/PreviewNotice.tsx
+++ b/src/features/publish/PreviewNotice.tsx
@@ -1,0 +1,241 @@
+// {/* CN:LICENSING-FINAL-START */}
+import React from 'react';
+import type { Authority } from '@/lib/authorities';
+import * as UI from '@/styles/ui';
+import {
+  type PublishState,
+  buildPremisesNotice,
+  buildVariationNotice,
+  buildReviewNotice,
+} from './previewBuilders';
+
+export type PreviewNoticeProps = {
+  draft: PublishState;
+  authority: Authority | null;
+  ocrText: string;
+  onReplaceOcr: (next: string) => void;
+};
+
+const SOURCE_OPTIONS: Array<{ value: 'ocr' | 'structured'; label: string }> = [
+  { value: 'ocr', label: 'OCR text' },
+  { value: 'structured', label: 'Structured fields' },
+];
+
+const buildStructuredNotice = (
+  draft: PublishState,
+  authority: Authority | null,
+  includeSummaries: boolean
+) => {
+  switch (draft.noticeType) {
+    case 'variation':
+      return buildVariationNotice(draft, authority, { includeSummaries });
+    case 'review':
+      return buildReviewNotice(draft, authority, { includeSummaries });
+    case 'premises':
+    default:
+      return buildPremisesNotice(draft, authority, { includeSummaries });
+  }
+};
+
+export default function PreviewNotice(props: PreviewNoticeProps) {
+  const { draft, authority, ocrText, onReplaceOcr } = props;
+  const hasOcr = ocrText.trim().length > 0;
+  const [source, setSource] = React.useState<'ocr' | 'structured'>(hasOcr ? 'ocr' : 'structured');
+  const prevHasOcr = React.useRef(hasOcr);
+
+  React.useEffect(() => {
+    if (hasOcr && !prevHasOcr.current) {
+      setSource('ocr');
+    }
+    if (!hasOcr) {
+      setSource('structured');
+    }
+    prevHasOcr.current = hasOcr;
+  }, [hasOcr]);
+
+  const structuredPreview = React.useMemo(
+    () => buildStructuredNotice(draft, authority, !hasOcr),
+    [draft, authority, hasOcr]
+  );
+  const structuredReplacement = React.useMemo(
+    () => buildStructuredNotice(draft, authority, true),
+    [draft, authority]
+  );
+
+  const previewText = source === 'structured' ? structuredPreview : ocrText;
+  const previewIsEmpty = previewText.trim().length === 0;
+
+  const lines = React.useMemo(() => previewText.split(/\r?\n/), [previewText]);
+  const headingOne = lines[0]?.trim();
+  const headingTwo = lines[1]?.trim();
+  const bodyLines = React.useMemo(() => {
+    const rest = lines.slice(2);
+    return rest;
+  }, [lines]);
+
+  const copy = React.useCallback(async () => {
+    if (previewIsEmpty) return;
+    try {
+      await navigator.clipboard?.writeText(previewText);
+    } catch {
+      /* noop */
+    }
+  }, [previewIsEmpty, previewText]);
+
+  const download = React.useCallback(() => {
+    if (previewIsEmpty) return;
+    const blob = new Blob([previewText], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'notice.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [previewIsEmpty, previewText]);
+
+  const handleReplace = React.useCallback(() => {
+    if (!structuredReplacement.trim()) return;
+    const confirmed = window.confirm('Replace OCR text with structured text? This will overwrite the scanned notice text.');
+    if (!confirmed) return;
+    onReplaceOcr(structuredReplacement);
+    setSource('ocr');
+  }, [structuredReplacement, onReplaceOcr]);
+
+  const trimmed = (value?: string | null) => value?.trim() || '';
+  const hasApplicant = !!trimmed(draft.applicantName);
+  const hasCouncilName = !!trimmed(draft.councilName);
+  const hasCouncilEmail = !!trimmed(draft.councilEmail);
+  const hasAddress = !!trimmed(draft.premisesAddress);
+  const hasSubmission = !!trimmed(draft.applicationDate);
+  const hasDeadline = (() => {
+    const value = draft.representationDeadline;
+    if (!value) return false;
+    if (value instanceof Date) {
+      return !Number.isNaN(value.getTime());
+    }
+    return value.trim().length > 0;
+  })();
+  const contactEmail = trimmed(authority?.repsEmail) || trimmed(draft.councilEmail);
+  const contactUrl = trimmed(authority?.repsUrl);
+  const contactPostal = trimmed(authority?.postalAddress) || trimmed(draft.councilAddress);
+  const hasContact = !!(contactEmail || contactUrl || contactPostal);
+
+  const needsPremisesSummary = !hasOcr && draft.noticeType === 'premises';
+  const needsVariationSummary = !hasOcr && draft.noticeType === 'variation';
+  const needsReviewGrounds = !hasOcr && draft.noticeType === 'review';
+
+  const premisesSummaryOk = !needsPremisesSummary || !!trimmed(draft.applicationSummary);
+  const variationSummaryOk = !needsVariationSummary || (!!trimmed(draft.applicationSummary) && !!trimmed(draft.variationSummary));
+  const reviewSummaryOk = !needsReviewGrounds || !!trimmed(draft.reviewGrounds);
+
+  const showBanner = !(
+    hasApplicant &&
+    hasCouncilName &&
+    hasCouncilEmail &&
+    hasAddress &&
+    hasSubmission &&
+    hasDeadline &&
+    hasContact &&
+    premisesSummaryOk &&
+    variationSummaryOk &&
+    reviewSummaryOk
+  );
+
+  return (
+    <div aria-label="Notice preview" className={`${UI.card} ${UI.cardHover} relative min-h-[360px] space-y-4 p-4 md:p-5`}>
+      <div className="flex flex-col gap-3 border-b border-slate-200/80 pb-3 md:flex-row md:items-start md:justify-between md:gap-4">
+        <div>
+          <h3 className="text-[13px] font-medium text-slate-700">Preview</h3>
+          <p className="mt-1 text-xs text-slate-600">Generated as you type</p>
+        </div>
+        <div className="flex flex-col items-stretch gap-2 md:items-end">
+          <div role="radiogroup" aria-label="Preview source" className="inline-flex rounded-full border border-slate-300 bg-white p-0.5 text-xs font-medium text-[#192650]">
+            {SOURCE_OPTIONS.map((opt) => {
+              const active = source === opt.value;
+              const disabled = opt.value === 'ocr' && !hasOcr;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  disabled={disabled}
+                  onClick={() => setSource(opt.value)}
+                  className={`rounded-full px-3 py-1 transition ${
+                    active ? 'bg-[#192650] text-white shadow-sm' : 'text-[#192650]'
+                  } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            onClick={handleReplace}
+            disabled={!structuredReplacement.trim()}
+            className={`${UI.btnSecondary} h-9 px-3 text-xs`}
+          >
+            Replace OCR with structured text
+          </button>
+        </div>
+      </div>
+      {showBanner && (
+        <div
+          role="status"
+          className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900"
+          data-testid="preview-status"
+        >
+          Some fields are missing — the notice text will update as you complete the form.
+        </div>
+      )}
+      <div id="notice-preview" className="min-h-[300px] rounded-xl border border-slate-900/5 bg-white p-4">
+        {previewIsEmpty ? (
+          <div className="space-y-2 animate-pulse">
+            <div className="h-3 rounded bg-slate-200/70" />
+            <div className="h-3 w-11/12 rounded bg-slate-200/70" />
+            <div className="h-3 w-9/12 rounded bg-slate-200/70" />
+            <div className="h-3 w-7/12 rounded bg-slate-200/70" />
+          </div>
+        ) : (
+          <div className={`${UI.prose} prose-p:my-2`}>
+            {headingOne && <h4 className="mt-0 text-sm font-semibold tracking-wide text-[#192650]">{headingOne.toUpperCase()}</h4>}
+            {headingTwo && <p className="-mt-2 text-[13px] font-medium text-slate-700">{headingTwo}</p>}
+            {bodyLines.map((line, index) =>
+              line.trim() ? (
+                <p key={index} className="text-[14px] leading-6 text-slate-800 whitespace-pre-wrap">
+                  {line}
+                </p>
+              ) : (
+                <p key={index} className="text-[14px] leading-6 text-slate-800">&nbsp;</p>
+              )
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={copy}
+          disabled={previewIsEmpty}
+          className={`rounded-md border px-2 py-1 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-blue-600 ${
+            previewIsEmpty ? 'cursor-not-allowed text-slate-400' : 'text-[#192650] hover:bg-white/60'
+          }`}
+        >
+          Copy text
+        </button>
+        <button
+          type="button"
+          onClick={download}
+          disabled={previewIsEmpty}
+          className={`rounded-md border px-2 py-1 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-blue-600 ${
+            previewIsEmpty ? 'cursor-not-allowed text-slate-400' : 'text-[#192650] hover:bg-white/60'
+          }`}
+        >
+          Download .txt
+        </button>
+      </div>
+    </div>
+  );
+}
+// {/* CN:LICENSING-FINAL-END */}

--- a/src/features/publish/previewBuilders.ts
+++ b/src/features/publish/previewBuilders.ts
@@ -1,10 +1,12 @@
 /* CN:STEP2-COMPLIANCE-START */
+// {/* CN:LICENSING-FINAL-START */}
 import { formatDisplayDate } from '@/lib/format';
 import type { Authority } from '@/lib/authorities';
 import type { NoticeDraft, NoticeType } from '@/types/notice';
 
 export type PublishState = Partial<NoticeDraft> & {
   representationDeadline?: string | Date | null;
+  ocrText?: string | null;
 };
 
 /* CN:TEMPLATES-PREVIEW-START */
@@ -20,28 +22,33 @@ const trimOrDash = (value?: string | null) => {
   return trimmed ? trimmed : dash;
 };
 
+const ensureSentence = (value?: string | null) => {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+};
+
 function formatDeadline(value?: string | Date | null): string {
   if (!value) return dash;
   const formatted = formatDisplayDate(value);
   return formatted || dash;
 }
 
-function repsLines(auth: Authority | null, council: string) {
-  const lines: string[] = [];
-  if (auth?.repsUrl) {
-    lines.push(`Online: ${auth.repsUrl}`);
-  }
-  if (auth?.repsEmail) {
-    lines.push(`Email: ${auth.repsEmail}`);
-  }
-  if (auth?.postalAddress) {
-    lines.push(`Postal: ${auth.postalAddress}`);
-  }
-  if (!lines.length) {
-    lines.push(`Contact ${council}`);
-  }
-  return lines;
-}
+const repsLines = (state: PublishState, auth: Authority | null) => {
+  const online = auth?.repsUrl?.trim() || '';
+  const email = (auth?.repsEmail || state.councilEmail || '').trim();
+  const postal = (auth?.postalAddress || state.councilAddress || '').trim();
+  return [
+    `Online: ${online || dash}`,
+    `Email: ${email || dash}`,
+    `Postal: ${postal || dash}`,
+  ];
+};
+
+type BuildOptions = {
+  includeSummaries?: boolean;
+};
 
 export function headingForNotice(type: NoticeType | undefined): [string, string] {
   switch (type) {
@@ -55,71 +62,133 @@ export function headingForNotice(type: NoticeType | undefined): [string, string]
   }
 }
 
-export function buildPremisesNotice(state: PublishState, auth: Authority | null): string {
+export function buildPremisesNotice(
+  state: PublishState,
+  auth: Authority | null,
+  options: BuildOptions = {}
+): string {
   const council = trimOrDash(state.councilName);
   const applicant = trimOrDash(state.applicantName);
   const address = trimOrDash(state.premisesAddress);
-  const summary = trimOrDash(state.applicationSummary);
   const deadline = formatDeadline(state.representationDeadline);
-  const summaryLine = summary !== dash ? `Proposed licensable activities/hours: ${summary}.` : '';
+  const summary = ensureSentence(state.applicationSummary);
+  const includeSummaries = options.includeSummaries === true;
 
-  return [
+  const lines: string[] = [
     ...headingForNotice('premises'),
-    `Notice is hereby given that ${applicant} has applied to ${council} for a Premises Licence in respect of:`,
-    `${address}.`,
-    summaryLine,
-    'Any person wishing to make representations regarding this application should write to:',
-    ...repsLines(auth, council),
-    `Representations must be received by ${deadline}.`,
-    offenceLine,
-  ]
-    .filter(Boolean)
-    .join('\n');
+    '',
+    `Notice is hereby given that ${applicant} has applied to ${council} for a Premises Licence for the premises below.`,
+    '',
+    `Premises address: ${address}`,
+  ];
+
+  if (includeSummaries && summary) {
+    lines.push('', `Summary of licensable activities/hours: ${summary}`);
+  }
+
+  const deadlineLine = deadline === dash
+    ? 'Representations must be received no later than —'
+    : `Representations must be received no later than ${deadline}.`;
+
+  lines.push(
+    '',
+    'How to make representations:',
+    ...repsLines(state, auth),
+    '',
+    deadlineLine,
+    offenceLine
+  );
+
+  return lines.join('\n');
 }
 
-export function buildVariationNotice(state: PublishState, auth: Authority | null): string {
+export function buildVariationNotice(
+  state: PublishState,
+  auth: Authority | null,
+  options: BuildOptions = {}
+): string {
   const council = trimOrDash(state.councilName);
   const applicant = trimOrDash(state.applicantName);
   const address = trimOrDash(state.premisesAddress);
-  const summary = trimOrDash(state.variationSummary || state.applicationSummary);
   const deadline = formatDeadline(state.representationDeadline);
-  const summaryLine = summary !== dash ? `Nature of the proposed variation: ${summary}.` : '';
+  const includeSummaries = options.includeSummaries === true;
+  const appSummary = ensureSentence(state.applicationSummary);
+  const variationSummary = ensureSentence(state.variationSummary);
 
-  return [
+  const lines: string[] = [
     ...headingForNotice('variation'),
-    `Notice is hereby given that ${applicant} has applied to ${council} to vary the Premises Licence at:`,
-    `${address}.`,
-    summaryLine,
-    'Any person wishing to make representations regarding this application should write to:',
-    ...repsLines(auth, council),
-    `Representations must be received by ${deadline}.`,
-    offenceLine,
-  ]
-    .filter(Boolean)
-    .join('\n');
+    '',
+    `Notice is hereby given that ${applicant} has applied to ${council} to vary a Premises Licence at the premises below.`,
+    '',
+    `Premises address: ${address}`,
+  ];
+
+  if (includeSummaries) {
+    const paragraphs = [
+      appSummary ? `Summary of licensable activities/hours: ${appSummary}` : '',
+      variationSummary ? `Nature of the proposed variation: ${variationSummary}` : '',
+    ].filter(Boolean);
+    if (paragraphs.length) {
+      lines.push('', ...paragraphs);
+    }
+  }
+
+  const deadlineLine = deadline === dash
+    ? 'Representations must be received no later than —'
+    : `Representations must be received no later than ${deadline}.`;
+
+  lines.push(
+    '',
+    'How to make representations:',
+    ...repsLines(state, auth),
+    '',
+    deadlineLine,
+    offenceLine
+  );
+
+  return lines.join('\n');
 }
 
-export function buildReviewNotice(state: PublishState, auth: Authority | null): string {
+export function buildReviewNotice(
+  state: PublishState,
+  auth: Authority | null,
+  options: BuildOptions = {}
+): string {
   const council = trimOrDash(state.councilName);
   const applicant = trimOrDash(state.applicantName);
   const address = trimOrDash(state.premisesAddress);
-  const grounds = trimOrDash(state.reviewGrounds);
   const deadline = formatDeadline(state.representationDeadline);
-  const groundsLine = grounds !== dash ? `Grounds for the review: ${grounds}.` : '';
+  const includeSummaries = options.includeSummaries === true;
+  const grounds = ensureSentence(state.reviewGrounds);
 
-  return [
+  const lines: string[] = [
     ...headingForNotice('review'),
-    `Notice is hereby given that an application has been made by ${applicant} to ${council} for a review of the Premises Licence at:`,
-    `${address}.`,
-    groundsLine,
-    'Any person wishing to make representations regarding this application should write to:',
-    ...repsLines(auth, council),
-    `Representations must be received by ${deadline}.`,
-    offenceLine,
-  ]
-    .filter(Boolean)
-    .join('\n');
+    '',
+    `Notice is hereby given that ${applicant} has applied to ${council} for a review of the Premises Licence at the premises below.`,
+    '',
+    `Premises address: ${address}`,
+  ];
+
+  if (includeSummaries && grounds) {
+    lines.push('', `Grounds for the review: ${grounds}`);
+  }
+
+  const deadlineLine = deadline === dash
+    ? 'Representations must be received no later than —'
+    : `Representations must be received no later than ${deadline}.`;
+
+  lines.push(
+    '',
+    'How to make representations:',
+    ...repsLines(state, auth),
+    '',
+    deadlineLine,
+    offenceLine
+  );
+
+  return lines.join('\n');
 }
+// {/* CN:LICENSING-FINAL-END */}
 /* CN:LICENSING-TEMPLATES-END */
 /* CN:TEMPLATES-PREVIEW-END */
 /* CN:STEP2-COMPLIANCE-END */

--- a/src/lib/licensing/checks.ts
+++ b/src/lib/licensing/checks.ts
@@ -59,9 +59,17 @@ export function runMandatoryChecks(draft: NoticeDraft): ComplianceResult {
   /* CN:STEP2-COMPLIANCE-START */
   // Aggregate representation contact presence (email OR URL OR postal)
   {
+    // {/* CN:LICENSING-FINAL-START */}
     const auth = getAuthorityByName(draft.councilName);
-    const hasAny = !!(draft.councilEmail?.trim() || draft.councilAddress?.trim() || auth?.repsUrl);
-    push('repsContact', hasAny, 'At least one representation contact (email, URL or postal) present', 'repsContact');
+    const hasAny = !!(
+      draft.councilEmail?.trim() ||
+      draft.councilAddress?.trim() ||
+      auth?.repsUrl ||
+      auth?.repsEmail ||
+      auth?.postalAddress
+    );
+    push('repsContact', hasAny, 'At least one representation contact present (email, URL or postal)', 'repsContact');
+    // {/* CN:LICENSING-FINAL-END */}
   }
   /* CN:STEP2-COMPLIANCE-END */
   push('applicationDate', !!draft.applicationDate?.trim(), 'Application date present', 'applicationDate');


### PR DESCRIPTION
## Summary
- add structured Licensing Act notice builders with two-line headings, contact block, and formatted deadlines
- integrate a preview source toggle with safe OCR replacement and conditional field requirements in the upload flow
- surface formatted key dates, updated checklist messaging, and OCR microcopy guidance

## Testing
- `npm run lint` *(fails: missing @eslint/js because registry access is restricted in the environment)*
- `npm run test` *(fails: vitest binary unavailable without installing dependencies in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bc0e5dc88330b8ed683d24c364ad