### PR TITLE
feat: add officer safeguard flow enhancements

### DIFF
--- a/src/components/publish/Checklist.tsx
+++ b/src/components/publish/Checklist.tsx
@@ -1,6 +1,20 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import * as UI from '@/styles/ui';
+/* CN:OFFICER-FINAL-START */
+function focusAndFlash(id: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  const focusable =
+    (el.querySelector('input,select,textarea,button,[tabindex]') as HTMLElement | null) || (el as HTMLElement | null);
+  focusable?.focus?.();
+  el.classList.add('outline', 'outline-2', 'outline-blue-300');
+  setTimeout(() => {
+    el.classList.remove('outline', 'outline-2', 'outline-blue-300');
+  }, 700);
+}
+/* CN:OFFICER-FINAL-END */
 
 export type ChecklistItem = {
   id: string;
@@ -40,9 +54,9 @@ export default function Checklist(props: Props) {
       return;
     }
     if (!target) return;
-    const el = document.getElementById(target) as HTMLElement | null;
-    el?.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
-    (el?.querySelector('input,select,textarea,button,[tabindex]') as HTMLElement | null)?.focus?.();
+    /* CN:OFFICER-FINAL-START */
+    focusAndFlash(target);
+    /* CN:OFFICER-FINAL-END */
   };
 
   const allGood = items.every((i) => i.ok);

--- a/src/components/publish/RightRail/KeyDatesCard.tsx
+++ b/src/components/publish/RightRail/KeyDatesCard.tsx
@@ -24,8 +24,9 @@ export default function KeyDatesCard({
   /* CN:STEP2-START */
   const hasSubmission = !!applicationDate;
   // {/* CN:LICENSING-FINAL-START */}
+  /* CN:OFFICER-FINAL-START */
   const submissionIso = hasSubmission ? `${applicationDate}T00:00:00` : '';
-  const submissionDisplay = hasSubmission ? formatDisplayDate(submissionIso) : '—';
+  const submissionDisplay = hasSubmission ? formatDisplayDate(submissionIso) : '';
   // {/* CN:LICENSING-FINAL-END */}
   const derivedDeadline = React.useMemo(() => {
     if (representationDeadline) return representationDeadline;
@@ -37,7 +38,10 @@ export default function KeyDatesCard({
   /* CN:STEP2-COMPLIANCE-UPGRADE-START */
   /* CN:TEMPLATES-PREVIEW-START */
   /* CN:LICENSING-TEMPLATES-START */
-  const deadlineDisplay = derivedDeadline ? formatDisplayDate(derivedDeadline) : '—';
+  const deadlineDisplay = derivedDeadline ? formatDisplayDate(derivedDeadline) : '';
+  const submissionPlaceholder = 'Set in Step 2';
+  const deadlinePlaceholder = 'Set in Step 2';
+  /* CN:OFFICER-FINAL-END */
   /* CN:LICENSING-TEMPLATES-END */
   /* CN:TEMPLATES-PREVIEW-END */
   /* CN:STEP2-COMPLIANCE-UPGRADE-END */
@@ -72,7 +76,13 @@ export default function KeyDatesCard({
           <dt className="font-medium">Application date</dt>
           <dd className="font-semibold">
             {/* CN:LICENSING-FINAL-START */}
-            {hasSubmission ? <time dateTime={submissionIso}>{submissionDisplay}</time> : submissionDisplay}
+            {hasSubmission ? (
+              <time dateTime={submissionIso} className="font-semibold">
+                {submissionDisplay}
+              </time>
+            ) : (
+              <span className="text-xs font-normal text-slate-500">{submissionPlaceholder}</span>
+            )}
             {/* CN:LICENSING-FINAL-END */}
           </dd>
         </div>
@@ -81,7 +91,13 @@ export default function KeyDatesCard({
           <dd className="text-right font-semibold">
             {/* CN:LICENSING-FINAL-START */}
             <div>
-              {derivedDeadline ? <time dateTime={derivedDeadline}>{deadlineDisplay}</time> : deadlineDisplay}
+              {derivedDeadline ? (
+                <time dateTime={derivedDeadline} className="font-semibold">
+                  {deadlineDisplay}
+                </time>
+              ) : (
+                <span className="text-xs font-normal text-slate-500">{deadlinePlaceholder}</span>
+              )}
             </div>
             {/* CN:LICENSING-FINAL-END */}
             <span className="block text-xs font-normal text-slate-500">Licensing Act 2003</span>

--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -14,6 +14,10 @@ import { calculateRepresentationDeadline } from '@/lib/dates/licensing';
 /* CN:STEP2-COMPLIANCE-START */
 import { formatDisplayDate } from '@/lib/format';
 import { getAuthorityByName, emailDomainMatchesAuthority } from '@/lib/authorities';
+/* CN:OFFICER-FINAL-START */
+import { extractDeadlineFromOcr, normalizeUKPostcode } from '@/lib/text/extract';
+import { buildPremisesNotice, buildVariationNotice, buildReviewNotice } from '@/features/publish/previewBuilders';
+/* CN:OFFICER-FINAL-END */
 // {/* CN:LICENSING-FINAL-END */}
 /* CN:STEP2-COMPLIANCE-END */
 /* CN:STEP2-END */
@@ -102,6 +106,61 @@ export default function UploadNoticeFlow() {
   const needsVariationSummary = !hasOcrText && draft.noticeType === 'variation';
   const needsReviewGrounds = !hasOcrText && draft.noticeType === 'review';
   // {/* CN:LICENSING-FINAL-END */}
+  /* CN:OFFICER-FINAL-START */
+  const [ignoreOcrDeadlineConflict, setIgnoreOcrDeadlineConflict] = React.useState(false);
+  const previewAuthority = React.useMemo(() => getAuthorityByName(draft.councilName), [draft.councilName]);
+  const representationDeadlineDate = React.useMemo(() => {
+    if (draft.repsDeadline) {
+      const parsed = new Date(draft.repsDeadline);
+      if (!Number.isNaN(parsed.getTime())) return parsed;
+    }
+    if (!draft.applicationDate) return null;
+    const computed = calculateRepresentationDeadline(draft.applicationDate);
+    return Number.isNaN(computed.getTime()) ? null : computed;
+  }, [draft.applicationDate, draft.repsDeadline]);
+  const ocrDeadline = React.useMemo(() => extractDeadlineFromOcr(ocrText), [ocrText]);
+  const deadlinesConflict = React.useMemo(() => {
+    if (!ocrDeadline || !representationDeadlineDate) return false;
+    const key = (value: Date) => new Date(value).toISOString().slice(0, 10);
+    return key(ocrDeadline) !== key(representationDeadlineDate);
+  }, [ocrDeadline, representationDeadlineDate]);
+  const showDeadlineWarning = deadlinesConflict && !ignoreOcrDeadlineConflict;
+  React.useEffect(() => {
+    setIgnoreOcrDeadlineConflict(false);
+  }, [ocrText, draft.applicationDate]);
+  const structuredReplacement = React.useMemo(() => {
+    if (!draft.noticeType) return '';
+    const representationIso = representationDeadlineDate ? representationDeadlineDate.toISOString() : '';
+    const builderState = { ...draft, representationDeadline: representationIso };
+    if (draft.noticeType === 'variation') {
+      return buildVariationNotice(builderState, previewAuthority, { includeSummaries: true });
+    }
+    if (draft.noticeType === 'review') {
+      return buildReviewNotice(builderState, previewAuthority, { includeSummaries: true });
+    }
+    return buildPremisesNotice(builderState, previewAuthority, { includeSummaries: true });
+  }, [draft, previewAuthority, representationDeadlineDate]);
+  const handleUseCalculatedDeadline = React.useCallback(() => {
+    const replacement = structuredReplacement.trim();
+    if (replacement) {
+      setOcrText(replacement);
+      setDraft((prev) => ({ ...prev, finalText: replacement }));
+    }
+    setIgnoreOcrDeadlineConflict(true);
+  }, [setDraft, setIgnoreOcrDeadlineConflict, setOcrText, structuredReplacement]);
+  const handleKeepOcrDeadline = React.useCallback(() => {
+    setIgnoreOcrDeadlineConflict(true);
+  }, [setIgnoreOcrDeadlineConflict]);
+  const handleViewOcrDeadline = React.useCallback(() => {
+    const preview = document.getElementById('notice-preview');
+    if (!preview) return;
+    preview.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    preview.classList.add('outline', 'outline-2', 'outline-amber-400');
+    setTimeout(() => {
+      preview.classList.remove('outline', 'outline-2', 'outline-amber-400');
+    }, 700);
+  }, []);
+  /* CN:OFFICER-FINAL-END */
 
   const summariesOk =
     (!needsApplicationSummary || !!draft.applicationSummary?.trim()) &&
@@ -322,6 +381,14 @@ export default function UploadNoticeFlow() {
                   // {/* CN:LICENSING-FINAL-START */}
                   hasOcrText={hasOcrText}
                   // {/* CN:LICENSING-FINAL-END */}
+                  /* CN:OFFICER-FINAL-START */
+                  ocrDeadline={ocrDeadline}
+                  showDeadlineWarning={showDeadlineWarning}
+                  onUseCalculatedDeadline={handleUseCalculatedDeadline}
+                  onKeepOcrDeadline={handleKeepOcrDeadline}
+                  onViewOcrDeadline={handleViewOcrDeadline}
+                  representationDeadlineDate={representationDeadlineDate}
+                  /* CN:OFFICER-FINAL-END */
                 />
                 {/* CN:STEP2-END */}
               </section>
@@ -357,6 +424,14 @@ export default function UploadNoticeFlow() {
                   // {/* CN:LICENSING-FINAL-START */}
                   hasOcrText={hasOcrText}
                   // {/* CN:LICENSING-FINAL-END */}
+                  /* CN:OFFICER-FINAL-START */
+                  ocrDeadline={ocrDeadline}
+                  showDeadlineWarning={showDeadlineWarning}
+                  onUseCalculatedDeadline={handleUseCalculatedDeadline}
+                  onKeepOcrDeadline={handleKeepOcrDeadline}
+                  onViewOcrDeadline={handleViewOcrDeadline}
+                  representationDeadlineDate={representationDeadlineDate}
+                  /* CN:OFFICER-FINAL-END */
                 />
                 {/* CN:STEP2-END */}
                 <div className="mt-4 flex items-center justify-between">
@@ -454,14 +529,13 @@ export default function UploadNoticeFlow() {
               {/* CN:STEP2-COMPLIANCE-START */}
               {(() => {
                 // {/* CN:LICENSING-FINAL-START */}
-                const auth = getAuthorityByName(draft.councilName);
-                const representationIso =
-                  draft.repsDeadline || (draft.applicationDate ? calculateRepresentationDeadline(draft.applicationDate).toISOString() : '');
+                /* CN:OFFICER-FINAL-START */
+                const representationIso = representationDeadlineDate ? representationDeadlineDate.toISOString() : '';
                 const builderState = { ...draft, representationDeadline: representationIso, ocrText };
                 return (
                   <PreviewNotice
                     draft={builderState}
-                    authority={auth}
+                    authority={previewAuthority}
                     ocrText={ocrText}
                     onReplaceOcr={(next) => {
                       setOcrText(next);
@@ -469,6 +543,7 @@ export default function UploadNoticeFlow() {
                     }}
                   />
                 );
+                /* CN:OFFICER-FINAL-END */
                 // {/* CN:LICENSING-FINAL-END */}
               })()}
               {/* CN:STEP2-COMPLIANCE-END */}
@@ -505,10 +580,35 @@ type NoticeDetailsSectionsProps = {
   // {/* CN:LICENSING-FINAL-START */}
   hasOcrText: boolean;
   // {/* CN:LICENSING-FINAL-END */}
+  /* CN:OFFICER-FINAL-START */
+  ocrDeadline: Date | null;
+  showDeadlineWarning: boolean;
+  onUseCalculatedDeadline: () => void;
+  onKeepOcrDeadline: () => void;
+  onViewOcrDeadline: () => void;
+  representationDeadlineDate: Date | null;
+  /* CN:OFFICER-FINAL-END */
 };
 
 function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
-  const { draft, onChange, refs, confirmA, confirmB, onConfirmAChange, onConfirmBChange, hasOcrText } = props;
+  const {
+    draft,
+    onChange,
+    refs,
+    confirmA,
+    confirmB,
+    onConfirmAChange,
+    onConfirmBChange,
+    hasOcrText,
+    /* CN:OFFICER-FINAL-START */
+    ocrDeadline,
+    showDeadlineWarning,
+    onUseCalculatedDeadline,
+    onKeepOcrDeadline,
+    onViewOcrDeadline,
+    representationDeadlineDate,
+    /* CN:OFFICER-FINAL-END */
+  } = props;
   /* CN:STEP2-COMPLIANCE-START */
   const [ignoreDomainWarning, setIgnoreDomainWarning] = React.useState(false);
   /* CN:STEP2-COMPLIANCE-END */
@@ -523,6 +623,19 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
   const councilAddressHelpId = React.useId();
   const submissionHelpId = React.useId();
   const deadlineHelpId = React.useId();
+  /* CN:OFFICER-FINAL-START */
+  const submissionTooltipId = React.useId();
+  const [showSubmissionTooltip, setShowSubmissionTooltip] = React.useState(false);
+  const [postcodeNormalizedAt, setPostcodeNormalizedAt] = React.useState<number>(0);
+  React.useEffect(() => {
+    if (!postcodeNormalizedAt) return;
+    const timer = setTimeout(() => setPostcodeNormalizedAt(0), 2000);
+    return () => clearTimeout(timer);
+  }, [postcodeNormalizedAt]);
+  const showPostcodeNormalised = postcodeNormalizedAt > 0;
+  const formattedOcrDeadline = ocrDeadline ? formatDisplayDate(ocrDeadline) : '';
+  const formattedCalculatedDeadline = representationDeadlineDate ? formatDisplayDate(representationDeadlineDate) : '';
+  /* CN:OFFICER-FINAL-END */
   /* CN:TEMPLATES-PREVIEW-START */
   /* CN:LICENSING-TEMPLATES-START */
   const applicationSummaryHelpId = React.useId();
@@ -599,16 +712,23 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
   /* CN:LICENSING-TEMPLATES-END */
   /* CN:TEMPLATES-PREVIEW-END */
 
+  /* CN:OFFICER-FINAL-START */
   const representationIso = React.useMemo(() => {
+    if (representationDeadlineDate) return representationDeadlineDate.toISOString();
     if (draft.repsDeadline) return draft.repsDeadline;
     if (!draft.applicationDate) return '';
     const computed = calculateRepresentationDeadline(draft.applicationDate);
     return Number.isNaN(computed.getTime()) ? '' : computed.toISOString();
-  }, [draft.applicationDate, draft.repsDeadline]);
+  }, [representationDeadlineDate, draft.applicationDate, draft.repsDeadline]);
 
   /* CN:STEP2-COMPLIANCE-START */
-  const representationDisplay = representationIso ? formatDisplayDate(representationIso) : '—';
+  const representationDisplay = representationDeadlineDate
+    ? formatDisplayDate(representationDeadlineDate)
+    : representationIso
+    ? formatDisplayDate(representationIso)
+    : '';
   /* CN:STEP2-COMPLIANCE-END */
+  /* CN:OFFICER-FINAL-END */
 
   const handleAddressSelect = (option: AddressOption) => {
     const composed = option.label || [option.line1, option.city ?? option.town, option.postcode].filter(Boolean).join(', ');
@@ -721,11 +841,31 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
               className={`${UI.input} h-11 w-full rounded-xl px-3 text-sm`}
               value={draft.postcode}
               onChange={(e) => onChange({ postcode: e.target.value }, { ensureUrn: true })}
+              /* CN:OFFICER-FINAL-START */
+              onBlur={(event) => {
+                const normalized = normalizeUKPostcode(event.currentTarget.value);
+                if (normalized !== event.currentTarget.value) {
+                  event.currentTarget.value = normalized;
+                }
+                onChange({ postcode: normalized }, { ensureUrn: true });
+                if (normalized && normalized !== draft.postcode) {
+                  setPostcodeNormalizedAt(Date.now());
+                }
+                if (!normalized) {
+                  setPostcodeNormalizedAt(0);
+                }
+              }}
+              /* CN:OFFICER-FINAL-END */
               aria-describedby={postcodeHelpId}
             />
             <p id={postcodeHelpId} className="mt-1 min-h-5 text-xs text-neutral-500">
               Matches the final notice address.
             </p>
+            {/* CN:OFFICER-FINAL-START */}
+            {showPostcodeNormalised && (
+              <p className="mt-1 text-xs text-neutral-500">Normalised</p>
+            )}
+            {/* CN:OFFICER-FINAL-END */}
           </div>
           <div className="col-span-12 md:col-span-6">
             <label htmlFor="councilName" className={UI.label}>
@@ -857,6 +997,9 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
                     className={`${UI.input} min-h-[96px] w-full rounded-xl px-3 text-sm`}
                     value={draft.applicationSummary || ''}
                     onChange={(e) => onChange({ applicationSummary: e.target.value })}
+                    /* CN:OFFICER-FINAL-START */
+                    required={needsAppSummary}
+                    /* CN:OFFICER-FINAL-END */
                     aria-invalid={applicationSummaryError ? 'true' : undefined}
                     aria-describedby={applicationSummaryDescribedBy || undefined}
                   />
@@ -885,6 +1028,9 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
                     className={`${UI.input} min-h-[96px] w-full rounded-xl px-3 text-sm`}
                     value={draft.variationSummary || ''}
                     onChange={(e) => onChange({ variationSummary: e.target.value })}
+                    /* CN:OFFICER-FINAL-START */
+                    required={needsVariationSummary}
+                    /* CN:OFFICER-FINAL-END */
                     aria-invalid={variationSummaryError ? 'true' : undefined}
                     aria-describedby={variationSummaryDescribedBy || undefined}
                   />
@@ -913,6 +1059,9 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
                     className={`${UI.input} min-h-[96px] w-full rounded-xl px-3 text-sm`}
                     value={draft.reviewGrounds || ''}
                     onChange={(e) => onChange({ reviewGrounds: e.target.value })}
+                    /* CN:OFFICER-FINAL-START */
+                    required={needsReviewGrounds}
+                    /* CN:OFFICER-FINAL-END */
                     aria-invalid={reviewGroundsError ? 'true' : undefined}
                     aria-describedby={reviewGroundsDescribedBy || undefined}
                   />
@@ -934,9 +1083,37 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
             <h3 className="text-sm font-semibold text-brand-navy">Dates &amp; declarations</h3>
           </div>
           <div className="col-span-12 md:col-span-6">
-            <label htmlFor="submissionDate" className={UI.label}>
-              Date of submission<span className="text-rose-600">*</span>
-            </label>
+            {/* CN:OFFICER-FINAL-START */}
+            <div className="flex items-center justify-between gap-2">
+              <label htmlFor="submissionDate" className={UI.label}>
+                Date of submission<span className="text-rose-600">*</span>
+              </label>
+              <div className="relative">
+                <button
+                  type="button"
+                  aria-label="Submission date guidance"
+                  aria-describedby={submissionTooltipId}
+                  aria-expanded={showSubmissionTooltip}
+                  onFocus={() => setShowSubmissionTooltip(true)}
+                  onBlur={() => setShowSubmissionTooltip(false)}
+                  onMouseEnter={() => setShowSubmissionTooltip(true)}
+                  onMouseLeave={() => setShowSubmissionTooltip(false)}
+                  className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-[11px] text-slate-600 transition hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white"
+                >
+                  i
+                </button>
+                {showSubmissionTooltip && (
+                  <div
+                    id={submissionTooltipId}
+                    role="tooltip"
+                    className="absolute right-0 top-full z-10 mt-2 w-64 rounded-lg border border-slate-200 bg-white p-3 text-xs text-slate-700 shadow-lg"
+                  >
+                    Enter the date the application was submitted to the licensing authority.
+                  </div>
+                )}
+              </div>
+            </div>
+            {/* CN:OFFICER-FINAL-END */}
             <input
               id="submissionDate"
               type="date"
@@ -947,9 +1124,11 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
               onChange={(e) => handleSubmissionDate(e.target.value)}
               aria-describedby={submissionHelpId}
             />
+            {/* CN:OFFICER-FINAL-START */}
             <p id={submissionHelpId} className="mt-1 min-h-5 text-xs text-neutral-500">
-              When you submitted the application to the licensing authority.
+              Used to calculate the 28-day representation deadline.
             </p>
+            {/* CN:OFFICER-FINAL-END */}
           </div>
           <div className="col-span-12 md:col-span-6">
             <label htmlFor="representationDeadline" className={UI.label}>
@@ -957,7 +1136,9 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
             </label>
             <input
               id="representationDeadline"
-              className="h-11 w-full rounded-xl border border-[rgba(25,38,80,0.12)] bg-neutral-50 px-3 text-sm text-neutral-700"
+              /* CN:OFFICER-FINAL-START */
+              className="h-11 w-full rounded-xl border border-slate-200 bg-neutral-50 px-3 text-sm text-neutral-700"
+              /* CN:OFFICER-FINAL-END */
               value={representationDisplay}
               readOnly
               aria-readonly="true"
@@ -969,6 +1150,43 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
               Auto-calculated <strong>28 calendar days</strong> after submission.
             </p>
           </div>
+          {/* CN:OFFICER-FINAL-START */}
+          {showDeadlineWarning && (
+            <div className="col-span-12">
+              <div className="flex flex-wrap items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-xs text-amber-900">
+                <span className="font-medium">OCR deadline differs from the calculated deadline.</span>
+                {(formattedOcrDeadline || formattedCalculatedDeadline) && (
+                  <span className="text-[11px] text-amber-800">
+                    OCR: {formattedOcrDeadline || '—'} · Calculated: {formattedCalculatedDeadline || '—'}
+                  </span>
+                )}
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className={`${UI.btnSecondary} py-1 px-2 text-xs`}
+                    onClick={onUseCalculatedDeadline}
+                  >
+                    Use calculated
+                  </button>
+                  <button
+                    type="button"
+                    className={`${UI.btnSecondary} py-1 px-2 text-xs`}
+                    onClick={onKeepOcrDeadline}
+                  >
+                    Keep OCR
+                  </button>
+                  <button
+                    type="button"
+                    className={`${UI.btnSecondary} py-1 px-2 text-xs`}
+                    onClick={onViewOcrDeadline}
+                  >
+                    View in OCR
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+          {/* CN:OFFICER-FINAL-END */}
           {/* CN:STEP2-COMPLIANCE-START */}
           {/* How to make representations (read-only) */}
           <div className="col-span-12">

--- a/src/components/upload/FileDropOCR.tsx
+++ b/src/components/upload/FileDropOCR.tsx
@@ -144,7 +144,13 @@ export default function FileDropOCR({ onText, onMeta }: FileDropOCRProps) {
         </div>
       )}
 
-      <div className="mt-3 text-xs text-slate-700">Status: {state} {elapsed ? `(${Math.round(elapsed)} ms)` : ''}</div>
+      {/* CN:OFFICER-FINAL-START */}
+      <div className="mt-3 flex items-center gap-2 text-xs text-neutral-500">
+        {state === 'ready' && <span aria-hidden className="text-emerald-600">✔</span>}
+        <span>Upload status: {statusLabel}</span>
+        {elapsed ? <span>({Math.round(elapsed)} ms)</span> : null}
+      </div>
+      {/* CN:OFFICER-FINAL-END */}
       {error && (
         <div className="mt-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-2" role="status" aria-live="polite">
           {error}

--- a/src/features/publish/PreviewNotice.tsx
+++ b/src/features/publish/PreviewNotice.tsx
@@ -63,7 +63,10 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
   );
 
   const previewText = source === 'structured' ? structuredPreview : ocrText;
-  const previewIsEmpty = previewText.trim().length === 0;
+  /* CN:OFFICER-FINAL-START */
+  const hasContent = previewText.trim().length > 0;
+  const previewIsEmpty = !hasContent;
+  /* CN:OFFICER-FINAL-END */
 
   const lines = React.useMemo(() => previewText.split(/\r?\n/), [previewText]);
   const headingOne = lines[0]?.trim();
@@ -74,16 +77,16 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
   }, [lines]);
 
   const copy = React.useCallback(async () => {
-    if (previewIsEmpty) return;
+    if (!hasContent) return;
     try {
       await navigator.clipboard?.writeText(previewText);
     } catch {
       /* noop */
     }
-  }, [previewIsEmpty, previewText]);
+  }, [hasContent, previewText]);
 
   const download = React.useCallback(() => {
-    if (previewIsEmpty) return;
+    if (!hasContent) return;
     const blob = new Blob([previewText], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -91,7 +94,7 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
     a.download = 'notice.txt';
     a.click();
     URL.revokeObjectURL(url);
-  }, [previewIsEmpty, previewText]);
+  }, [hasContent, previewText]);
 
   const handleReplace = React.useCallback(() => {
     if (!structuredReplacement.trim()) return;
@@ -217,9 +220,9 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
         <button
           type="button"
           onClick={copy}
-          disabled={previewIsEmpty}
+          disabled={!hasContent}
           className={`rounded-md border px-2 py-1 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-blue-600 ${
-            previewIsEmpty ? 'cursor-not-allowed text-slate-400' : 'text-[#192650] hover:bg-white/60'
+            hasContent ? 'text-[#192650] hover:bg-white/60' : 'cursor-not-allowed text-slate-400'
           }`}
         >
           Copy text
@@ -227,9 +230,9 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
         <button
           type="button"
           onClick={download}
-          disabled={previewIsEmpty}
+          disabled={!hasContent}
           className={`rounded-md border px-2 py-1 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-blue-600 ${
-            previewIsEmpty ? 'cursor-not-allowed text-slate-400' : 'text-[#192650] hover:bg-white/60'
+            hasContent ? 'text-[#192650] hover:bg-white/60' : 'cursor-not-allowed text-slate-400'
           }`}
         >
           Download .txt

--- a/src/features/publish/previewBuilders.ts
+++ b/src/features/publish/previewBuilders.ts
@@ -35,16 +35,22 @@ function formatDeadline(value?: string | Date | null): string {
   return formatted || dash;
 }
 
+/* CN:OFFICER-FINAL-START */
 const repsLines = (state: PublishState, auth: Authority | null) => {
   const online = auth?.repsUrl?.trim() || '';
   const email = (auth?.repsEmail || state.councilEmail || '').trim();
   const postal = (auth?.postalAddress || state.councilAddress || '').trim();
-  return [
+  const lines = [
     `Online: ${online || dash}`,
     `Email: ${email || dash}`,
     `Postal: ${postal || dash}`,
   ];
+  if (!online && !email && !postal) {
+    lines.push('⚠ Missing: online form / email / postal address');
+  }
+  return lines;
 };
+/* CN:OFFICER-FINAL-END */
 
 type BuildOptions = {
   includeSummaries?: boolean;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,4 +1,5 @@
 /* CN:STEP2-COMPLIANCE-UPGRADE-START */
+/* CN:OFFICER-FINAL-START */
 // Legacy export kept for back-compat; prefer formatDisplayDateTime
 export function formatDisplayDate(d: Date | string | null): string {
   if (!d) return '';
@@ -29,4 +30,5 @@ export function formatDisplayDateTime(d?: Date | string | null): string {
     hour12: false,
   });
 }
+/* CN:OFFICER-FINAL-END */
 /* CN:STEP2-COMPLIANCE-UPGRADE-END */

--- a/src/lib/licensing/checks.ts
+++ b/src/lib/licensing/checks.ts
@@ -92,7 +92,9 @@ export function runMandatoryChecks(draft: NoticeDraft): ComplianceResult {
     push(
       'repsDeadline',
       false,
-      'This notice does not state the representation deadline — please enter manually.',
+      /* CN:OFFICER-FINAL-START */
+      'Set the submission date to auto-calculate the representation deadline.',
+      /* CN:OFFICER-FINAL-END */
       'applicationDate',
       'warning'
     );

--- a/src/lib/text/extract.ts
+++ b/src/lib/text/extract.ts
@@ -1,0 +1,91 @@
+/* CN:OFFICER-FINAL-START */
+const MONTH_LOOKUP: Record<string, number> = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  sept: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
+const normalizeMonthToken = (token: string) => token.trim().toLowerCase();
+
+const monthIndex = (token: string) => {
+  const normalized = normalizeMonthToken(token);
+  if (normalized in MONTH_LOOKUP) return MONTH_LOOKUP[normalized];
+  const short = normalized.slice(0, 3);
+  if (short in MONTH_LOOKUP) return MONTH_LOOKUP[short];
+  return -1;
+};
+
+const resolveYear = (value: number) => {
+  if (value >= 100) return value;
+  if (value >= 50) return 1900 + value;
+  return 2000 + value;
+};
+
+const withTime = (date: Date, time?: string | null) => {
+  if (!time) {
+    date.setHours(23, 59, 0, 0);
+    return date;
+  }
+  const [hh, mm] = time.split(':').map((part) => Number.parseInt(part, 10));
+  if (Number.isNaN(hh) || Number.isNaN(mm)) {
+    date.setHours(23, 59, 0, 0);
+    return date;
+  }
+  date.setHours(hh, mm, 0, 0);
+  return date;
+};
+
+export function extractDeadlineFromOcr(ocr: string): Date | null {
+  if (!ocr) return null;
+  const sample = ocr.split(/\r?\n/).slice(0, 200).join('\n');
+
+  const numericMatch = sample.match(/\b(\d{1,2})[\/.\-](\d{1,2})[\/.\-](\d{2,4})(?:[, ]+(\d{1,2}:\d{2}))?\b/i);
+  if (numericMatch) {
+    const day = Number.parseInt(numericMatch[1] || '', 10);
+    const month = Number.parseInt(numericMatch[2] || '', 10) - 1;
+    const year = resolveYear(Number.parseInt(numericMatch[3] || '', 10));
+    if (!Number.isNaN(day) && !Number.isNaN(month) && !Number.isNaN(year) && month >= 0 && month <= 11) {
+      const dt = new Date(year, month, day);
+      if (!Number.isNaN(dt.getTime())) {
+        return withTime(dt, numericMatch[4]);
+      }
+    }
+  }
+
+  const textualRegex = new RegExp(
+    String.raw`\b(\d{1,2})\s+(jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+(\d{2,4})(?:,?\s+(\d{1,2}:\d{2}))?\b`,
+    'i'
+  );
+  const textualMatch = sample.match(textualRegex);
+  if (textualMatch) {
+    const day = Number.parseInt(textualMatch[1] || '', 10);
+    const month = monthIndex(textualMatch[2] || '');
+    const year = resolveYear(Number.parseInt(textualMatch[3] || '', 10));
+    if (!Number.isNaN(day) && month >= 0 && month <= 11 && !Number.isNaN(year)) {
+      const dt = new Date(year, month, day);
+      if (!Number.isNaN(dt.getTime())) {
+        return withTime(dt, textualMatch[4]);
+      }
+    }
+  }
+
+  return null;
+}
+
+export function normalizeUKPostcode(input: string): string {
+  if (!input) return input;
+  const compact = input.replace(/\s+/g, '').toUpperCase();
+  if (compact.length <= 3) return compact;
+  return `${compact.slice(0, -3)} ${compact.slice(-3)}`;
+}
+/* CN:OFFICER-FINAL-END */


### PR DESCRIPTION
## Summary
- auto-calculate representation deadlines with OCR conflict handling, postcode normalisation, and notice-type text requirements in the upload flow
- harmonise preview output, key dates, and checklists with new deadline formatting and representation contact messaging
- add OCR deadline parser, disable preview actions without content, and tone down upload status feedback

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c37c6a64833091aff39ca4193f68