### PR TITLE
Finalize sign-off polish for Step 2

### DIFF
--- a/src/components/publish/Checklist.tsx
+++ b/src/components/publish/Checklist.tsx
@@ -2,18 +2,16 @@ import React, { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import * as UI from '@/styles/ui';
 /* CN:OFFICER-FINAL-START */
+/* CN:SIGNOFF-START */
 function focusAndFlash(id: string) {
   const el = document.getElementById(id);
   if (!el) return;
   el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  const focusable =
-    (el.querySelector('input,select,textarea,button,[tabindex]') as HTMLElement | null) || (el as HTMLElement | null);
-  focusable?.focus?.();
+  (el as HTMLInputElement | HTMLTextAreaElement | null)?.focus?.();
   el.classList.add('outline', 'outline-2', 'outline-blue-300');
-  setTimeout(() => {
-    el.classList.remove('outline', 'outline-2', 'outline-blue-300');
-  }, 700);
+  setTimeout(() => el.classList.remove('outline', 'outline-2', 'outline-blue-300'), 700);
 }
+/* CN:SIGNOFF-END */
 /* CN:OFFICER-FINAL-END */
 
 export type ChecklistItem = {

--- a/src/components/publish/UploadDropzone.tsx
+++ b/src/components/publish/UploadDropzone.tsx
@@ -139,9 +139,10 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
       )}
 
       {/* CN:GUARDRAIL-FINAL-START */}
+      {/* CN:SIGNOFF-START */}
       {state === 'ready' ? (
         <p className="mt-3 flex items-center gap-1 text-xs text-neutral-500">
-          <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+          <span aria-hidden className="inline-block h-2 w-2 rounded-full bg-emerald-500"></span>
           Ready
         </p>
       ) : (
@@ -150,6 +151,7 @@ export default function UploadDropzone({ onText, onMeta }: UploadDropzoneProps) 
           {elapsed && state !== 'idle' ? ` (${Math.round(elapsed)} ms)` : ''}
         </div>
       )}
+      {/* CN:SIGNOFF-END */}
       {/* CN:GUARDRAIL-FINAL-END */}
       {error && (
         <div className="mt-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-2" role="status" aria-live="polite">

--- a/src/components/publish/UploadNoticeFlow.tsx
+++ b/src/components/publish/UploadNoticeFlow.tsx
@@ -40,16 +40,16 @@ type NoticeFieldRefs = {
 /* CN:STEP2-END */
 
 /* CN:STEP2-LAYOUT-START */
+/* CN:SIGNOFF-START */
 function focusAndFlash(id: string) {
-  const el = document.getElementById(id) as HTMLElement | null;
+  const el = document.getElementById(id);
   if (!el) return;
   el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  (el as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).focus?.();
+  (el as HTMLInputElement | HTMLTextAreaElement | null)?.focus?.();
   el.classList.add('outline', 'outline-2', 'outline-blue-300');
-  setTimeout(() => {
-    el.classList.remove('outline', 'outline-2', 'outline-blue-300');
-  }, 700);
+  setTimeout(() => el.classList.remove('outline', 'outline-2', 'outline-blue-300'), 700);
 }
+/* CN:SIGNOFF-END */
 /* CN:STEP2-LAYOUT-END */
 
 export default function UploadNoticeFlow() {
@@ -626,15 +626,16 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
   /* CN:OFFICER-FINAL-START */
   const submissionTooltipId = React.useId();
   const [showSubmissionTooltip, setShowSubmissionTooltip] = React.useState(false);
-  const [postcodeNormalizedAt, setPostcodeNormalizedAt] = React.useState<number>(0);
+  /* CN:SIGNOFF-START */
+  const [postcodeNormalised, setPostcodeNormalised] = React.useState(false);
   React.useEffect(() => {
-    if (!postcodeNormalizedAt) return;
+    if (!postcodeNormalised) return;
     /* CN:GUARDRAIL-FINAL-START */
-    const timer = setTimeout(() => setPostcodeNormalizedAt(0), 1500);
+    const timer = setTimeout(() => setPostcodeNormalised(false), 1000);
     /* CN:GUARDRAIL-FINAL-END */
     return () => clearTimeout(timer);
-  }, [postcodeNormalizedAt]);
-  const showPostcodeNormalised = postcodeNormalizedAt > 0;
+  }, [postcodeNormalised]);
+  /* CN:SIGNOFF-END */
   const formattedOcrDeadline = ocrDeadline ? formatDisplayDate(ocrDeadline) : '';
   const formattedCalculatedDeadline = representationDeadlineDate ? formatDisplayDate(representationDeadlineDate) : '';
   /* CN:OFFICER-FINAL-END */
@@ -844,6 +845,7 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
               value={draft.postcode}
               onChange={(e) => onChange({ postcode: e.target.value }, { ensureUrn: true })}
               /* CN:OFFICER-FINAL-START */
+              /* CN:SIGNOFF-START */
               onBlur={(event) => {
                 const normalized = normalizeUKPostcode(event.currentTarget.value);
                 if (normalized !== event.currentTarget.value) {
@@ -851,12 +853,13 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
                 }
                 onChange({ postcode: normalized }, { ensureUrn: true });
                 if (normalized && normalized !== draft.postcode) {
-                  setPostcodeNormalizedAt(Date.now());
+                  setPostcodeNormalised(true);
                 }
                 if (!normalized) {
-                  setPostcodeNormalizedAt(0);
+                  setPostcodeNormalised(false);
                 }
               }}
+              /* CN:SIGNOFF-END */
               /* CN:OFFICER-FINAL-END */
               aria-describedby={postcodeHelpId}
             />
@@ -864,9 +867,9 @@ function NoticeDetailsSections(props: NoticeDetailsSectionsProps) {
               Matches the final notice address.
             </p>
             {/* CN:OFFICER-FINAL-START */}
-            {showPostcodeNormalised && (
-              <p className="mt-1 text-xs text-neutral-500">Normalised</p>
-            )}
+            {/* CN:SIGNOFF-START */}
+            {postcodeNormalised && <p className="mt-1 text-xs text-neutral-500">Normalised</p>}
+            {/* CN:SIGNOFF-END */}
             {/* CN:OFFICER-FINAL-END */}
           </div>
           <div className="col-span-12 md:col-span-6">

--- a/src/features/publish/PreviewNotice.tsx
+++ b/src/features/publish/PreviewNotice.tsx
@@ -169,65 +169,58 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
 
   return (
     <div aria-label="Notice preview" className={`${UI.card} ${UI.cardHover} relative min-h-[360px] space-y-4 p-4 md:p-5`}>
-      <div className="flex flex-col gap-3 border-b border-slate-200/80 pb-3 md:flex-row md:items-start md:justify-between md:gap-4">
+      {/* CN:SIGNOFF-START */}
+      <div className="flex flex-col gap-3 border-b border-slate-200/80 pb-3 md:flex-row md:items-center md:justify-between md:gap-4">
         <div>
           <h3 className="text-[13px] font-medium text-slate-700">Preview</h3>
           <p className="mt-1 text-xs text-slate-600">Generated as you type</p>
         </div>
-        <div className="flex flex-col items-stretch gap-2 md:items-end">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs font-medium text-slate-600">Source:</span>
-            <div
-              role="tablist"
-              aria-label="Preview source"
-              className="inline-flex overflow-hidden rounded-lg border border-slate-300 bg-white text-xs font-medium text-[#192650]"
+        {/* CN:SIGNOFF-START */}
+        <div className="flex flex-wrap items-center gap-3 md:justify-end">
+          <span className="text-xs text-neutral-600">Source:</span>
+          <div
+            role="tablist"
+            aria-label="Preview source"
+            className="inline-flex overflow-hidden rounded-lg border border-slate-300 bg-white"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={previewSource === 'ocr'}
+              disabled={!hasOcr}
+              onClick={() => hasOcr && setPreviewSource('ocr')}
+              className={`px-2.5 py-1 text-xs font-medium transition ${
+                previewSource === 'ocr' && hasOcr ? 'bg-[#192650] text-white shadow-sm' : 'text-[#192650]'
+              } ${!hasOcr ? 'cursor-not-allowed opacity-40' : ''}`}
             >
-              <button
-                type="button"
-                role="tab"
-                aria-selected={previewSource === 'ocr'}
-                disabled={!hasOcr}
-                onClick={() => hasOcr && setPreviewSource('ocr')}
-                className={`px-3 py-1 transition ${
-                  previewSource === 'ocr' && hasOcr ? 'bg-[#192650] text-white shadow-sm' : 'text-[#192650]'
-                } ${!hasOcr ? 'cursor-not-allowed opacity-40' : ''}`}
-              >
-                OCR text
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={previewSource === 'structured'}
-                onClick={() => setPreviewSource('structured')}
-                className={`px-3 py-1 transition ${
-                  previewSource === 'structured' ? 'bg-[#192650] text-white shadow-sm' : 'text-[#192650]'
-                }`}
-              >
-                Structured fields
-              </button>
-            </div>
-            {hasOcr && (
-              <button
-                type="button"
-                onClick={handleReplace}
-                disabled={!structuredReplacement.trim()}
-                className="text-xs text-blue-700 underline underline-offset-2 hover:text-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:ring-offset-white"
-              >
-                Replace OCR with structured text
-              </button>
-            )}
+              OCR text
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={previewSource === 'structured'}
+              onClick={() => setPreviewSource('structured')}
+              className={`px-2.5 py-1 text-xs font-medium transition ${
+                previewSource === 'structured' ? 'bg-[#192650] text-white shadow-sm' : 'text-[#192650]'
+              }`}
+            >
+              Structured fields
+            </button>
           </div>
-          {toastMessage && (
-            <div
-              role="status"
-              aria-live="polite"
-              className="self-end rounded-full bg-slate-900/90 px-3 py-1 text-[11px] font-medium text-white shadow-sm"
+          {hasOcr && (
+            <button
+              type="button"
+              onClick={handleReplace}
+              disabled={!structuredReplacement.trim()}
+              className="text-xs text-[#192650] underline underline-offset-2 hover:text-[#0f1b39] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
             >
-              {toastMessage}
-            </div>
+              Replace OCR with structured text
+            </button>
           )}
         </div>
+        {/* CN:SIGNOFF-END */}
       </div>
+      {/* CN:SIGNOFF-END */}
       {showBanner && (
         <div
           role="status"
@@ -283,6 +276,17 @@ export default function PreviewNotice(props: PreviewNoticeProps) {
           Download .txt
         </button>
       </div>
+      {/* CN:SIGNOFF-START */}
+      {toastMessage && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 rounded-md bg-black/80 px-3 py-2 text-xs text-white shadow-lg"
+        >
+          {toastMessage}
+        </div>
+      )}
+      {/* CN:SIGNOFF-END */}
     </div>
   );
 }

--- a/src/features/publish/previewBuilders.ts
+++ b/src/features/publish/previewBuilders.ts
@@ -29,28 +29,27 @@ const ensureSentence = (value?: string | null) => {
   return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
 };
 
-function formatDeadline(value?: string | Date | null): string {
-  if (!value) return dash;
-  const formatted = formatDisplayDate(value);
-  return formatted || dash;
-}
-
-/* CN:OFFICER-FINAL-START */
-const repsLines = (state: PublishState, auth: Authority | null) => {
-  const online = auth?.repsUrl?.trim() || '';
-  const email = (auth?.repsEmail || state.councilEmail || '').trim();
-  const postal = (auth?.postalAddress || state.councilAddress || '').trim();
-  const lines = [
+/* CN:SIGNOFF-START */
+const buildRepresentationsSection = (state: PublishState, authority: Authority | null): string[] => {
+  const online = authority?.repsUrl?.trim() || '';
+  const email = (authority?.repsEmail || state.councilEmail || '').trim();
+  const postal = (authority?.postalAddress || state.councilAddress || '').trim();
+  const section = [
+    'How to make representations:',
     `Online: ${online || dash}`,
-    `Email: ${email || dash}`,
+    `Email:  ${email || dash}`,
     `Postal: ${postal || dash}`,
   ];
   if (!online && !email && !postal) {
-    lines.push('⚠ Missing: online form / email / postal address');
+    section.push('Missing: online form / email / postal address');
   }
-  return lines;
+  const deadlineValue = state.representationDeadline ?? state.repsDeadline ?? null;
+  if (deadlineValue) {
+    section.push(`Representations must be received no later than ${formatDisplayDate(deadlineValue)}.`);
+  }
+  return section;
 };
-/* CN:OFFICER-FINAL-END */
+/* CN:SIGNOFF-END */
 
 type BuildOptions = {
   includeSummaries?: boolean;
@@ -76,7 +75,6 @@ export function buildPremisesNotice(
   const council = trimOrDash(state.councilName);
   const applicant = trimOrDash(state.applicantName);
   const address = trimOrDash(state.premisesAddress);
-  const deadline = formatDeadline(state.representationDeadline);
   const summary = ensureSentence(state.applicationSummary);
   const includeSummaries = options.includeSummaries === true;
 
@@ -92,18 +90,14 @@ export function buildPremisesNotice(
     lines.push('', `Summary of licensable activities/hours: ${summary}`);
   }
 
-  const deadlineLine = deadline === dash
-    ? 'Representations must be received no later than —'
-    : `Representations must be received no later than ${deadline}.`;
-
+  /* CN:SIGNOFF-START */
   lines.push(
     '',
-    'How to make representations:',
-    ...repsLines(state, auth),
+    ...buildRepresentationsSection(state, auth),
     '',
-    deadlineLine,
     offenceLine
   );
+  /* CN:SIGNOFF-END */
 
   return lines.join('\n');
 }
@@ -116,7 +110,6 @@ export function buildVariationNotice(
   const council = trimOrDash(state.councilName);
   const applicant = trimOrDash(state.applicantName);
   const address = trimOrDash(state.premisesAddress);
-  const deadline = formatDeadline(state.representationDeadline);
   const includeSummaries = options.includeSummaries === true;
   const appSummary = ensureSentence(state.applicationSummary);
   const variationSummary = ensureSentence(state.variationSummary);
@@ -139,18 +132,14 @@ export function buildVariationNotice(
     }
   }
 
-  const deadlineLine = deadline === dash
-    ? 'Representations must be received no later than —'
-    : `Representations must be received no later than ${deadline}.`;
-
+  /* CN:SIGNOFF-START */
   lines.push(
     '',
-    'How to make representations:',
-    ...repsLines(state, auth),
+    ...buildRepresentationsSection(state, auth),
     '',
-    deadlineLine,
     offenceLine
   );
+  /* CN:SIGNOFF-END */
 
   return lines.join('\n');
 }
@@ -163,7 +152,6 @@ export function buildReviewNotice(
   const council = trimOrDash(state.councilName);
   const applicant = trimOrDash(state.applicantName);
   const address = trimOrDash(state.premisesAddress);
-  const deadline = formatDeadline(state.representationDeadline);
   const includeSummaries = options.includeSummaries === true;
   const grounds = ensureSentence(state.reviewGrounds);
 
@@ -179,18 +167,14 @@ export function buildReviewNotice(
     lines.push('', `Grounds for the review: ${grounds}`);
   }
 
-  const deadlineLine = deadline === dash
-    ? 'Representations must be received no later than —'
-    : `Representations must be received no later than ${deadline}.`;
-
+  /* CN:SIGNOFF-START */
   lines.push(
     '',
-    'How to make representations:',
-    ...repsLines(state, auth),
+    ...buildRepresentationsSection(state, auth),
     '',
-    deadlineLine,
     offenceLine
   );
+  /* CN:SIGNOFF-END */
 
   return lines.join('\n');
 }

--- a/src/pages/publish/index.tsx
+++ b/src/pages/publish/index.tsx
@@ -17,14 +17,16 @@ import { validateTrafficOrder } from '../../../schemas/rules/traffic-order.rules
 import * as UI from '@/styles/ui';
 
 /* CN:FIX-START */
+/* CN:SIGNOFF-START */
 function focusAndFlash(id: string) {
   const el = document.getElementById(id);
   if (!el) return;
   el.scrollIntoView({ behavior: 'smooth', block: 'center' });
   (el as HTMLInputElement | HTMLTextAreaElement | null)?.focus?.();
-  el.classList.add('outline','outline-2','outline-blue-300');
-  setTimeout(() => el.classList.remove('outline','outline-2','outline-blue-300'), 700);
+  el.classList.add('outline', 'outline-2', 'outline-blue-300');
+  setTimeout(() => el.classList.remove('outline', 'outline-2', 'outline-blue-300'), 700);
 }
+/* CN:SIGNOFF-END */
 /* CN:FIX-END */
 
 function useDebounce<T>(val: T, ms = 250) {


### PR DESCRIPTION
## Summary
- polish the Step 2 preview header with tablist toggle and persistent copy/download toast placement
- normalise postcode blur behaviour, simplify focus helpers, and tone down the upload status indicator
- rebuild representation preview content with consistent key dates mirroring and accessibility-friendly checklist behaviour

## Testing
- npm run test *(fails: vitest executable missing in environment)*
- npm run lint *(fails: @eslint/js module missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d02ed76c83308294402a4cb94d8e