### PR TITLE
Upload via Template — Compliance & UX refinements (parity preserved)

### DIFF
--- a/src/components/__tests__/ErrorSummary.test.tsx
+++ b/src/components/__tests__/ErrorSummary.test.tsx
@@ -7,7 +7,7 @@ describe('Error summary and fix links', () => {
     (HTMLFormElement.prototype as any).requestSubmit = () => {};
     render(<PublishPage />);
     // switch to gvol
-    fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'gvol' } });
+    fireEvent.change(screen.getByLabelText('Notice type'), { target: { value: 'gvol' } });
     fireEvent.click(screen.getAllByText('Submit')[1]);
     // error summary link
     const errLink = await screen.findAllByText(/is required/);

--- a/src/components/__tests__/NoticeTypeSelect.test.tsx
+++ b/src/components/__tests__/NoticeTypeSelect.test.tsx
@@ -5,16 +5,21 @@ import PublishPage from '@/pages/PublishPage';
 describe('NoticeTypeSelect', () => {
   it('renders only the active form when switching types', () => {
     render(<PublishPage />);
-    fireEvent.click(screen.getByText('Upload via Template'));
-    expect(screen.getByLabelText('Premises name')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Operator')).not.toBeInTheDocument();
+    const select = screen.getByLabelText('Notice type') as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'gvol' } });
-    expect(screen.getByLabelText('Operator')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Premises name')).not.toBeInTheDocument();
+    fireEvent.change(select, { target: { value: 'premises' } });
+    expect(select.value).toBe('premises');
+    expect(
+      screen.getByText('Alcohol/regulated entertainment & late-night refreshment.')
+    ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'traffic' } });
-    expect(screen.getByLabelText('Title')).toBeInTheDocument();
-    expect(screen.queryByLabelText('Operator')).not.toBeInTheDocument();
+    fireEvent.change(select, { target: { value: 'variation' } });
+    expect(select.value).toBe('variation');
+    expect(screen.getByText('Change to existing licence (hours, conditions, layout, etc.).')).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: 'review' } });
+    expect(select.value).toBe('review');
+    expect(screen.getByText('Application to review an existing licence.')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/PreviewTemplate.test.tsx
+++ b/src/components/__tests__/PreviewTemplate.test.tsx
@@ -1,27 +1,50 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import React from 'react';
 import PublishPage from '@/pages/PublishPage';
 
-describe('Preview template', () => {
-  it('uses template for selected notice type and expands', async () => {
+describe('Template builder preview', () => {
+  it('generates a premises notice preview after completing the builder flow', async () => {
     (HTMLFormElement.prototype as any).requestSubmit = () => {};
     render(<PublishPage />);
+
     fireEvent.click(screen.getByText('Upload via Template'));
-    fireEvent.change(screen.getByLabelText('What type of notice do you require?'), { target: { value: 'gvol' } });
-    // fill form
-    fireEvent.change(screen.getByLabelText('Applicant email'), { target: { value: 'a@example.com' } });
-    fireEvent.change(screen.getByLabelText('Council'), { target: { value: 'bristol' } });
-    // council email auto fills
-    fireEvent.change(screen.getByLabelText('Operator'), { target: { value: 'Acme' } });
-    fireEvent.change(screen.getByLabelText('Vehicles'), { target: { value: '1' } });
-    fireEvent.change(screen.getByLabelText('Trailers'), { target: { value: '0' } });
-    const submitButton = await screen.findByRole('button', { name: 'Submit' });
-    fireEvent.click(submitButton);
+    fireEvent.click(screen.getByRole('button', { name: /New premises licence/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
-    expect(await screen.findByText(/goods vehicle operator licence/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Applicant legal name'), { target: { value: 'Test Applicant Ltd' } });
+    const applicantAddress = screen.getByRole('group', { name: 'Applicant address' });
+    fireEvent.change(within(applicantAddress).getByLabelText('Address line 1'), { target: { value: '1 Market Street' } });
+    fireEvent.change(within(applicantAddress).getByLabelText('Town or city'), { target: { value: 'Bristol' } });
+    fireEvent.change(within(applicantAddress).getByLabelText('Postcode'), { target: { value: 'BS1 4ST' } });
 
-    const expandBtn = await screen.findByLabelText('Expand preview');
-    fireEvent.click(expandBtn);
-    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Contact email'), { target: { value: 'applicant@example.com' } });
+    fireEvent.change(screen.getByLabelText('Phone'), { target: { value: '02071234567' } });
+
+    fireEvent.change(screen.getByLabelText('Premises name'), { target: { value: 'The Market' } });
+    const premisesAddress = screen.getByRole('group', { name: 'Premises address' });
+    fireEvent.change(within(premisesAddress).getByLabelText('Address line 1'), { target: { value: '2 Market Street' } });
+    fireEvent.change(within(premisesAddress).getByLabelText('Town or city'), { target: { value: 'Bristol' } });
+    fireEvent.change(within(premisesAddress).getByLabelText('Postcode'), { target: { value: 'BS1 5ST' } });
+
+    fireEvent.change(screen.getByLabelText('Intended publication date'), { target: { value: '2024-05-01' } });
+
+    fireEvent.change(screen.getByLabelText('Council name'), { target: { value: 'Bristol City Council' } });
+    fireEvent.change(screen.getByLabelText('Representation email'), { target: { value: 'licensing@bristol.gov.uk' } });
+    fireEvent.change(screen.getByLabelText('Postal address for representations'), {
+      target: { value: 'Licensing Team\nCity Hall\nBristol BS1 5TR' },
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: '10:00–23:00' })[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Confirm your notice' })).toBeInTheDocument());
+
+    const previewHeadings = screen.getAllByText('Notice preview');
+    expect(previewHeadings[0]).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText(/Test Applicant Ltd/).length).toBeGreaterThan(0);
+      expect(screen.queryByText(/\[\[missing:/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/__tests__/PublishLayout.test.tsx
+++ b/src/components/__tests__/PublishLayout.test.tsx
@@ -8,6 +8,6 @@ describe('Publish layout', () => {
     expect(screen.getByText('Upload your Notice')).toBeInTheDocument();
     expect(screen.getByText('Preview')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Upload via Template'));
-    expect(screen.getByLabelText('Premises name')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Confirm notice type' })).toBeInTheDocument();
   });
 });

--- a/src/components/publish/NoticePreview.tsx
+++ b/src/components/publish/NoticePreview.tsx
@@ -7,6 +7,22 @@ export default function NoticePreview({ text }: { text: string }) {
   const reduceMotion = useReducedMotion();
   const safeText = React.useMemo(() => sanitiseNoticeText(text || ''), [text]);
   const isEmpty = !safeText.trim();
+  const segments = React.useMemo(() => {
+    const parts = safeText.split(/(\[\[missing:[^\]]+\]\])/g);
+    return parts.map((part, index) => {
+      if (/^\[\[missing:[^\]]+\]\]$/.test(part)) {
+        return (
+          <span
+            key={`missing-${index}`}
+            className="rounded bg-rose-50 px-1 py-0.5 text-xs font-medium text-rose-600"
+          >
+            {part}
+          </span>
+        );
+      }
+      return <React.Fragment key={`text-${index}`}>{part}</React.Fragment>;
+    });
+  }, [safeText]);
   const copyText = async () => {
     try {
       await navigator.clipboard?.writeText(safeText || '');
@@ -65,7 +81,7 @@ export default function NoticePreview({ text }: { text: string }) {
             transition={{ duration: reduceMotion ? 0 : 0.2 }}
             className="notice-preview max-h-[70vh] overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] font-mono text-sm leading-relaxed"
           >
-            {safeText}
+            {segments}
           </motion.pre>
         ) : (
           <motion.div

--- a/src/features/template/TemplateBuilderProvider.tsx
+++ b/src/features/template/TemplateBuilderProvider.tsx
@@ -118,19 +118,28 @@ export const TemplateBuilderProvider: React.FC<{ children: React.ReactNode }> = 
   }, [state.step]);
 
   useEffect(() => {
-    if (!state.notice.council) return;
     if (!state.notice.intendedPublicationDate) return;
+    if (state.notice.declEditMeta?.deadlineEdited) return;
     const deadline = calculateRepresentationDeadline(state.notice.intendedPublicationDate, {
-      shiftWeekend: state.notice.council.policy?.shiftWeekendDeadline === true,
+      shiftWeekend: state.notice.council?.policy?.shiftWeekendDeadline === true,
     });
     if (!deadline) return;
     if (deadline === state.notice.representationDeadline) return;
+    const patch: Partial<TemplateNotice> = { representationDeadline: deadline };
+    if (state.notice.declEditMeta) {
+      patch.declEditMeta = undefined;
+    }
     dispatch({
       type: 'PATCH_NOTICE',
-      patch: { representationDeadline: deadline },
+      patch,
       markDirty: false,
     });
-  }, [state.notice.council, state.notice.intendedPublicationDate, state.notice.representationDeadline]);
+  }, [
+    state.notice.intendedPublicationDate,
+    state.notice.council?.policy?.shiftWeekendDeadline,
+    state.notice.representationDeadline,
+    state.notice.declEditMeta?.deadlineEdited,
+  ]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/src/features/template/checks.ts
+++ b/src/features/template/checks.ts
@@ -1,33 +1,47 @@
 import type { ChecklistItem } from '@/components/publish/ComplianceChecklist';
 import { formatUKPostcode } from '@/lib/ukPostcode';
 import type { TemplateNotice } from './types';
+import { hasEnabledHours } from './noticeRenderer';
 
 export function buildChecklist(notice: TemplateNotice): ChecklistItem[] {
   const trimmed = (value?: string | null) => value?.trim() ?? '';
-  const postcodeOk = notice.premisesAddress?.postcode ? formatUKPostcode(notice.premisesAddress.postcode) : '';
-  const hasActivities = Object.values(notice.activities || {}).some((week: any) => {
-    if (!week) return false;
-    return Object.values(week).some((range: any) => range?.enabled);
-  });
-  const representationDate = trimmed(notice.representationDeadline);
+  const postcode = notice.premisesAddress?.postcode
+    ? formatUKPostcode(notice.premisesAddress.postcode)
+    : '';
+  const premisesAddressComplete =
+    trimmed(notice.premisesAddress?.line1).length > 0 &&
+    trimmed(notice.premisesAddress?.town).length > 0 &&
+    postcode.length > 0;
 
   const items: ChecklistItem[] = [
     {
-      id: 'applicant-name',
+      id: 'applicant-legal-name',
       label: 'Applicant legal name present',
-      ok: trimmed(notice.applicantName).length >= 2,
-      target: 'applicantName',
+      ok: trimmed(notice.applicantLegalName).length >= 2,
+      target: 'applicantLegalName',
     },
     {
-      id: 'premises-postcode',
-      label: 'Premises postcode captured',
-      ok: !!postcodeOk,
-      target: 'premises-address-picker-postcode',
+      id: 'applicant-phone',
+      label: 'Applicant phone provided',
+      ok: trimmed(notice.contactPhone).length >= 7,
+      target: 'contactPhone',
+    },
+    {
+      id: 'premises-name',
+      label: 'Premises or trading name provided',
+      ok: !!trimmed(notice.premisesName) || !!trimmed(notice.tradingName),
+      target: 'tradingName',
+    },
+    {
+      id: 'premises-address',
+      label: 'Premises address complete',
+      ok: premisesAddressComplete,
+      target: 'premisesAddress-line1',
     },
     {
       id: 'activities-hours',
       label: 'Activities and hours completed',
-      ok: hasActivities,
+      ok: hasEnabledHours(notice.activities),
       target: 'activities-grid',
     },
     {
@@ -39,8 +53,14 @@ export function buildChecklist(notice: TemplateNotice): ChecklistItem[] {
     {
       id: 'representation-deadline',
       label: 'Representation deadline calculated',
-      ok: representationDate.length > 0,
+      ok: !!trimmed(notice.representationDeadline),
       target: 'representationDeadline',
+    },
+    {
+      id: 'declaration',
+      label: 'Declaration confirmed',
+      ok: notice.declarationAccepted,
+      target: 'confirm-notice',
     },
   ];
 

--- a/src/features/template/components/ActivityHoursMatrix.tsx
+++ b/src/features/template/components/ActivityHoursMatrix.tsx
@@ -2,19 +2,61 @@ import React from 'react';
 import * as UI from '@/styles/ui';
 import type { Activities, ActivityKey, WeekHours } from '../types';
 import { DefaultWeekHours } from '../schema';
+import InfoTooltip from './InfoTooltip';
 
 const activityDefinitions: Array<{
   key: ActivityKey;
   label: string;
-  helper?: string;
+  description: React.ReactNode;
 }> = [
-  { key: 'alcoholOn', label: 'Sale of alcohol (on the premises)' },
-  { key: 'alcoholOff', label: 'Sale of alcohol (off the premises)' },
-  { key: 'lateRefreshment', label: 'Late night refreshment', helper: 'Hot food or drink between 23:00 and 05:00.' },
-  { key: 'liveMusic', label: 'Live music' },
-  { key: 'recordedMusic', label: 'Recorded music' },
-  { key: 'dance', label: 'Performance of dance' },
-  { key: 'similar', label: 'Anything of a similar description' },
+  {
+    key: 'alcoholOn',
+    label: 'Sale of alcohol (on-sales)',
+    description: 'Alcohol supplied for consumption on the premises.',
+  },
+  {
+    key: 'alcoholOff',
+    label: 'Sale of alcohol (off-sales)',
+    description: 'Alcohol supplied for consumption away from the premises.',
+  },
+  {
+    key: 'lateRefreshment',
+    label: 'Late night refreshment',
+    description: 'Hot food or drink served between 23:00 and 05:00.',
+  },
+  {
+    key: 'liveMusic',
+    label: 'Live music',
+    description: 'Performances of live music to the public.',
+  },
+  {
+    key: 'recordedMusic',
+    label: 'Recorded music',
+    description: 'Playing of recorded music to the public.',
+  },
+  {
+    key: 'dance',
+    label: 'Performance of dance',
+    description: 'Any performance of dance for an audience.',
+  },
+  {
+    key: 'similar',
+    label: 'Anything of a similar description',
+    description: (
+      <span>
+        Captures entertainment similar to live/recorded music or dance.{' '}
+        <a
+          href="https://www.gov.uk/guidance/alcohol-licensing"
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-blue-700 underline"
+        >
+          Read guidance
+        </a>
+        .
+      </span>
+    ),
+  },
 ];
 
 const days = [
@@ -26,6 +68,11 @@ const days = [
   { id: 'sat', label: 'Sat' },
   { id: 'sun', label: 'Sun' },
 ] as const;
+
+const presets = [
+  { label: '10:00–23:00', start: '10:00', end: '23:00' },
+  { label: '12:00–00:00', start: '12:00', end: '00:00' },
+];
 
 type Props = {
   value?: Activities;
@@ -58,29 +105,12 @@ export default function ActivityHoursMatrix({ value, onChange }: Props) {
     onChange(next);
   };
 
-  const toggleActivity = (key: ActivityKey, enable: boolean) => {
-    if (!enable) {
-      setActivity(key, (current) => {
-        const base = cloneWeekHours(current);
-        days.forEach((day) => {
-          base[day.id].enabled = false;
-        });
-        return base;
-      });
-      return;
-    }
-    setActivity(key, (current) => {
-      const base = cloneWeekHours(current);
-      days.forEach((day) => {
-        base[day.id].enabled = true;
-        base[day.id].start = base[day.id].start || '09:00';
-        base[day.id].end = base[day.id].end || '17:00';
-      });
-      return base;
-    });
-  };
-
-  const setDayRange = (key: ActivityKey, day: typeof days[number]['id'], field: 'start' | 'end', valueForField: string) => {
+  const setDayRange = (
+    key: ActivityKey,
+    day: (typeof days)[number]['id'],
+    field: 'start' | 'end',
+    valueForField: string
+  ) => {
     setActivity(key, (current) => {
       const base = cloneWeekHours(current);
       base[day].enabled = true;
@@ -91,11 +121,11 @@ export default function ActivityHoursMatrix({ value, onChange }: Props) {
     });
   };
 
-  const toggleDay = (key: ActivityKey, day: typeof days[number]['id'], enabled: boolean) => {
+  const toggleDayClosed = (key: ActivityKey, day: (typeof days)[number]['id'], closed: boolean) => {
     setActivity(key, (current) => {
       const base = cloneWeekHours(current);
-      base[day].enabled = enabled;
-      if (enabled) {
+      base[day].enabled = !closed;
+      if (!closed) {
         base[day].start = base[day].start || '09:00';
         base[day].end = base[day].end || '17:00';
       }
@@ -103,7 +133,7 @@ export default function ActivityHoursMatrix({ value, onChange }: Props) {
     });
   };
 
-  const copyToAllDays = (key: ActivityKey, from: typeof days[number]['id']) => {
+  const copyToAllDays = (key: ActivityKey, from: (typeof days)[number]['id']) => {
     setActivity(key, (current) => {
       const base = cloneWeekHours(current);
       const source = base[from];
@@ -114,96 +144,140 @@ export default function ActivityHoursMatrix({ value, onChange }: Props) {
     });
   };
 
+  const applyPreset = (key: ActivityKey, start: string, end: string) => {
+    setActivity(key, (current) => {
+      const base = cloneWeekHours(current);
+      days.forEach((day) => {
+        base[day.id].enabled = true;
+        base[day.id].start = start;
+        base[day.id].end = end;
+      });
+      return base;
+    });
+  };
+
+  const clearActivity = (key: ActivityKey) => {
+    setActivity(key, (current) => {
+      const base = cloneWeekHours(current);
+      days.forEach((day) => {
+        base[day.id].enabled = false;
+      });
+      return base;
+    });
+  };
+
   return (
-    <section className={`${UI.card} p-5 md:p-6 space-y-4`} aria-label="Licensable activities">
+    <section className={`${UI.card} p-5 md:p-6 space-y-4`} aria-label="Licensable activities" id="activities-grid">
       <div>
-        <h2 className="text-base font-semibold text-blue-900">Activities & hours</h2>
-        <p className="mt-1 text-sm text-slate-600">Enable each activity and enter hours for the relevant days. Use 24-hour time.</p>
+        <h2 className="text-base font-semibold text-blue-900">Activities &amp; hours</h2>
+        <p className="mt-1 text-sm text-slate-600">
+          Use 24-hour time. Mark days as closed where the activity is not authorised.
+        </p>
       </div>
       <div className="space-y-6">
         {activityDefinitions.map((activity) => {
           const week = value?.[activity.key];
-          const enabled = activityEnabled(week);
+          const anyOpen = activityEnabled(week);
           return (
-            <div key={activity.key} className="rounded-2xl border border-slate-200 p-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
+            <div
+              key={activity.key}
+              className={`rounded-2xl border p-4 transition ${
+                anyOpen ? 'border-slate-200 bg-white' : 'border-dashed border-slate-200 bg-slate-50/50'
+              }`}
+            >
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex items-center gap-2">
                   <h3 className="text-[15px] font-semibold text-blue-900">{activity.label}</h3>
-                  {activity.helper && <p className="mt-1 text-sm text-slate-600">{activity.helper}</p>}
+                  <InfoTooltip content={activity.description} label={`About ${activity.label}`} />
                 </div>
-                <label className="inline-flex items-center gap-2 text-sm font-medium text-blue-900">
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-blue-400 text-blue-600 focus:ring-blue-500"
-                    checked={enabled}
-                    onChange={(event) => toggleActivity(activity.key, event.target.checked)}
-                  />
-                  Enable
-                </label>
+                <div className="flex flex-wrap items-center gap-2">
+                  {presets.map((preset) => (
+                    <button
+                      type="button"
+                      key={preset.label}
+                      className="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                      onClick={() => applyPreset(activity.key, preset.start, preset.end)}
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    className="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    onClick={() => copyToAllDays(activity.key, 'mon')}
+                  >
+                    Copy Mon → all days
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                    onClick={() => clearActivity(activity.key)}
+                  >
+                    Mark all closed
+                  </button>
+                </div>
               </div>
-              {enabled && (
-                <div className="mt-4 overflow-x-auto">
-                  <table className="min-w-full text-sm">
-                    <thead className="text-left text-slate-600">
-                      <tr>
-                        <th className="py-2 pr-3">Day</th>
-                        <th className="py-2 pr-3">Open</th>
-                        <th className="py-2 pr-3">Start</th>
-                        <th className="py-2 pr-3">End</th>
-                        <th className="py-2 pr-3" />
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {days.map((day) => {
-                        const range = week?.[day.id] ?? { enabled: false, start: '', end: '' };
-                        return (
-                          <tr key={day.id} className="border-t">
-                            <td className="py-2 pr-3 font-medium text-slate-700">{day.label}</td>
-                            <td className="py-2 pr-3">
-                              <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-700">
-                                <input
-                                  type="checkbox"
-                                  className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                                  checked={range.enabled}
-                                  onChange={(event) => toggleDay(activity.key, day.id, event.target.checked)}
-                                />
-                                Open
-                              </label>
-                            </td>
-                            <td className="py-2 pr-3">
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead className="text-left text-slate-600">
+                    <tr>
+                      <th className="py-2 pr-3">Day</th>
+                      <th className="py-2 pr-3">Closed</th>
+                      <th className="py-2 pr-3">Start</th>
+                      <th className="py-2 pr-3">End</th>
+                      <th className="py-2 pr-3 text-right">Copy</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {days.map((day) => {
+                      const range = week?.[day.id] ?? { enabled: false, start: '', end: '' };
+                      return (
+                        <tr key={day.id} className="border-t">
+                          <td className="py-2 pr-3 font-medium text-slate-700">{day.label}</td>
+                          <td className="py-2 pr-3">
+                            <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-700">
                               <input
-                                type="time"
-                                className={`${UI.input} h-9 w-28 text-sm`}
-                                value={range.start || ''}
-                                disabled={!range.enabled}
-                                onChange={(event) => setDayRange(activity.key, day.id, 'start', event.target.value)}
+                                type="checkbox"
+                                className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                                checked={!range.enabled}
+                                onChange={(event) => toggleDayClosed(activity.key, day.id, event.target.checked)}
                               />
-                            </td>
-                            <td className="py-2 pr-3">
-                              <input
-                                type="time"
-                                className={`${UI.input} h-9 w-28 text-sm`}
-                                value={range.end || ''}
-                                disabled={!range.enabled}
-                                onChange={(event) => setDayRange(activity.key, day.id, 'end', event.target.value)}
-                              />
-                            </td>
-                            <td className="py-2 pr-3 text-right">
-                              <button
-                                type="button"
-                                className="text-xs font-medium text-blue-700 underline underline-offset-2"
-                                onClick={() => copyToAllDays(activity.key, day.id)}
-                              >
-                                Copy to all
-                              </button>
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              )}
+                              Closed
+                            </label>
+                          </td>
+                          <td className="py-2 pr-3">
+                            <input
+                              type="time"
+                              className={`${UI.input} h-9 w-28 text-sm`}
+                              value={range.start || ''}
+                              disabled={!range.enabled}
+                              onChange={(event) => setDayRange(activity.key, day.id, 'start', event.target.value)}
+                            />
+                          </td>
+                          <td className="py-2 pr-3">
+                            <input
+                              type="time"
+                              className={`${UI.input} h-9 w-28 text-sm`}
+                              value={range.end || ''}
+                              disabled={!range.enabled}
+                              onChange={(event) => setDayRange(activity.key, day.id, 'end', event.target.value)}
+                            />
+                          </td>
+                          <td className="py-2 pr-3 text-right">
+                            <button
+                              type="button"
+                              className="text-xs font-medium text-blue-700 underline underline-offset-2"
+                              onClick={() => copyToAllDays(activity.key, day.id)}
+                            >
+                              Copy to all days
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
             </div>
           );
         })}

--- a/src/features/template/components/AddressPicker.tsx
+++ b/src/features/template/components/AddressPicker.tsx
@@ -5,6 +5,8 @@ import { formatUKPostcode } from '@/lib/ukPostcode';
 import * as UI from '@/styles/ui';
 import type { AddressValue } from '../types';
 
+type AddressErrors = Partial<Record<keyof AddressValue, string>>;
+
 type AddressPickerProps = {
   id: string;
   label: string;
@@ -12,9 +14,22 @@ type AddressPickerProps = {
   onChange: (value: AddressValue) => void;
   helpText?: string;
   required?: boolean;
+  errors?: AddressErrors | null;
+  describedBy?: string;
+  footnote?: string;
 };
 
-export default function AddressPicker({ id, label, value, onChange, helpText, required = true }: AddressPickerProps) {
+export default function AddressPicker({
+  id,
+  label,
+  value,
+  onChange,
+  helpText,
+  required = true,
+  errors,
+  describedBy,
+  footnote,
+}: AddressPickerProps) {
   const [manual, setManual] = React.useState<AddressValue | null>(value ?? null);
   const handlePick = React.useCallback(
     (item: AddressItem) => {
@@ -61,17 +76,28 @@ export default function AddressPicker({ id, label, value, onChange, helpText, re
     setManual(value);
   }, [value?.line1, value?.line2, value?.town, value?.postcode]);
 
+  const helperId = helpText ? `${id}-helper` : undefined;
+  const describedByIds = [helperId, describedBy].filter(Boolean).join(' ') || undefined;
+
+  const fieldError = (field: keyof AddressValue): string | undefined => errors?.[field];
+  const inputClass = (field: keyof AddressValue) =>
+    `${UI.input} mt-1 w-full ${fieldError(field) ? 'border-amber-500 focus:border-amber-500 focus:ring-amber-200' : ''}`;
+
   return (
     <fieldset className="space-y-3" id={id} aria-labelledby={`${id}-label`}>
       <legend id={`${id}-label`} className="text-sm font-semibold text-blue-900">
         {label}
       </legend>
-      {helpText && <p className="text-sm text-slate-600">{helpText}</p>}
+      {helpText && (
+        <p id={helperId} className="text-sm text-slate-600">
+          {helpText}
+        </p>
+      )}
       <AddressSearch
         value={manual?.line1}
         onPick={handlePick}
         placeholder="Search for an address or postcode"
-        describedBy={`${id}-helper`}
+        describedBy={describedByIds}
         required={required}
       />
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
@@ -81,11 +107,18 @@ export default function AddressPicker({ id, label, value, onChange, helpText, re
           </label>
           <input
             id={`${id}-line1`}
-            className={`${UI.input} mt-1 w-full`}
+            className={inputClass('line1')}
             value={manual?.line1 ?? ''}
             onChange={(event) => handleManualChange({ line1: event.target.value })}
             required={required}
+            aria-invalid={fieldError('line1') ? 'true' : undefined}
+            aria-describedby={fieldError('line1') ? `${id}-line1-error` : describedByIds}
           />
+          {fieldError('line1') && (
+            <p id={`${id}-line1-error`} className="mt-1 text-sm text-amber-700">
+              {fieldError('line1')}
+            </p>
+          )}
         </div>
         <div>
           <label className="text-sm font-medium text-slate-700" htmlFor={`${id}-line2`}>
@@ -93,7 +126,7 @@ export default function AddressPicker({ id, label, value, onChange, helpText, re
           </label>
           <input
             id={`${id}-line2`}
-            className={`${UI.input} mt-1 w-full`}
+            className={inputClass('line2')}
             value={manual?.line2 ?? ''}
             onChange={(event) => handleManualChange({ line2: event.target.value })}
           />
@@ -104,10 +137,17 @@ export default function AddressPicker({ id, label, value, onChange, helpText, re
           </label>
           <input
             id={`${id}-town`}
-            className={`${UI.input} mt-1 w-full`}
+            className={inputClass('town')}
             value={manual?.town ?? ''}
             onChange={(event) => handleManualChange({ town: event.target.value })}
+            aria-invalid={fieldError('town') ? 'true' : undefined}
+            aria-describedby={fieldError('town') ? `${id}-town-error` : describedByIds}
           />
+          {fieldError('town') && (
+            <p id={`${id}-town-error`} className="mt-1 text-sm text-amber-700">
+              {fieldError('town')}
+            </p>
+          )}
         </div>
         <div>
           <label className="text-sm font-medium text-slate-700" htmlFor={`${id}-postcode`}>
@@ -115,13 +155,21 @@ export default function AddressPicker({ id, label, value, onChange, helpText, re
           </label>
           <input
             id={`${id}-postcode`}
-            className={`${UI.input} mt-1 w-full uppercase`}
+            className={`${inputClass('postcode')} uppercase`}
             value={manual?.postcode ?? ''}
             onChange={(event) => handleManualChange({ postcode: event.target.value.toUpperCase() })}
             required={required}
+            aria-invalid={fieldError('postcode') ? 'true' : undefined}
+            aria-describedby={fieldError('postcode') ? `${id}-postcode-error` : describedByIds}
           />
+          {fieldError('postcode') && (
+            <p id={`${id}-postcode-error`} className="mt-1 text-sm text-amber-700">
+              {fieldError('postcode')}
+            </p>
+          )}
         </div>
       </div>
+      {footnote && <p className="text-sm text-slate-600">{footnote}</p>}
     </fieldset>
   );
 }

--- a/src/features/template/components/CouncilContactAuto.tsx
+++ b/src/features/template/components/CouncilContactAuto.tsx
@@ -7,7 +7,6 @@ type Props = {
   postcode: string;
   value: CouncilValue | null;
   onChange: (value: CouncilValue) => void;
-  onManualEdit?: () => void;
 };
 
 const withDefaults = (base: CouncilValue | null | undefined): CouncilValue => ({
@@ -19,15 +18,17 @@ const withDefaults = (base: CouncilValue | null | undefined): CouncilValue => ({
   policy: base?.policy,
 });
 
-export default function CouncilContactAuto({ postcode, value, onChange, onManualEdit }: Props) {
+export default function CouncilContactAuto({ postcode, value, onChange }: Props) {
   const [lookupState, setLookupState] = React.useState<'idle' | 'loading' | 'error' | 'success'>('idle');
-  const [message, setMessage] = React.useState<string>('');
+  const [message, setMessage] = React.useState('');
+  const [manualOpen, setManualOpen] = React.useState(false);
 
   const runLookup = React.useCallback(() => {
     const trimmed = postcode.trim();
     if (!trimmed) {
       setMessage('Enter the premises postcode to look up the council.');
       setLookupState('error');
+      setManualOpen(true);
       return;
     }
     setLookupState('loading');
@@ -36,6 +37,7 @@ export default function CouncilContactAuto({ postcode, value, onChange, onManual
       if (!res) {
         setLookupState('error');
         setMessage('We could not match this postcode. Enter the council manually.');
+        setManualOpen(true);
         return;
       }
       const next: CouncilValue = {
@@ -47,15 +49,25 @@ export default function CouncilContactAuto({ postcode, value, onChange, onManual
       onChange(next);
       setLookupState('success');
       setMessage('Council details loaded from directory.');
+      setManualOpen(false);
     } catch (error) {
       console.error('Council lookup failed', error);
       setLookupState('error');
       setMessage('Lookup failed. Enter the details manually.');
+      setManualOpen(true);
     }
-  }, [onChange, postcode]);
+  }, [onChange, postcode, value]);
+
+  const hasSummary = Boolean((value?.name ?? '').trim() || (value?.repEmail ?? '').trim());
+
+  React.useEffect(() => {
+    if (!hasSummary) {
+      setManualOpen(true);
+    }
+  }, [hasSummary]);
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
         <button type="button" className={`${UI.btnSecondary} h-10 px-4 text-sm`} onClick={runLookup}>
           Auto-fill from postcode
@@ -63,51 +75,86 @@ export default function CouncilContactAuto({ postcode, value, onChange, onManual
         <button
           type="button"
           className="text-sm font-medium text-blue-700 underline underline-offset-2"
-          onClick={onManualEdit}
+          onClick={() => setManualOpen((prev) => !prev)}
         >
-          Enter manually
+          {manualOpen ? 'Hide manual entry' : 'Edit manually'}
         </button>
       </div>
-      {lookupState !== 'idle' && (
-        <p className={`text-sm ${lookupState === 'success' ? 'text-emerald-700' : 'text-amber-700'}`}>
-          {message}
-        </p>
+      {lookupState === 'error' && (
+        <div className="rounded-xl border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900" role="status">
+          {message || 'We could not match this postcode. Enter the council manually.'}
+        </div>
       )}
-      <div className="grid grid-cols-1 gap-3">
-        <div>
-          <label htmlFor="council-name" className="text-sm font-medium text-slate-700">
-            Council name
-          </label>
-          <input
-            id="council-name"
-            className={`${UI.input} mt-1 w-full`}
-            value={value?.name ?? ''}
-            onChange={(event) => onChange({ ...withDefaults(value), name: event.target.value })}
-          />
+      {lookupState === 'success' && message && !manualOpen && (
+        <p className="text-sm text-emerald-700">{message}</p>
+      )}
+      {!manualOpen && hasSummary && (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          Based on your premises address, this notice will be sent to{' '}
+          <strong>{value?.name || 'the council'}</strong> at <strong>{value?.repEmail || '—'}</strong>.
         </div>
-        <div>
-          <label htmlFor="council-email" className="text-sm font-medium text-slate-700">
-            Representation email
-          </label>
-          <input
-            id="council-email"
-            className={`${UI.input} mt-1 w-full`}
-            value={value?.repEmail ?? ''}
-            onChange={(event) => onChange({ ...withDefaults(value), repEmail: event.target.value })}
-          />
+      )}
+      {(manualOpen || !hasSummary) && (
+        <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
+          <div>
+            <label htmlFor="council-name" className="text-sm font-medium text-slate-700">
+              Council name
+            </label>
+            <input
+              id="council-name"
+              className={`${UI.input} mt-1 w-full`}
+              value={value?.name ?? ''}
+              onChange={(event) => onChange({ ...withDefaults(value), name: event.target.value })}
+            />
+          </div>
+          <div>
+            <label htmlFor="council-email" className="text-sm font-medium text-slate-700">
+              Representation email
+            </label>
+            <input
+              id="council-email"
+              className={`${UI.input} mt-1 w-full`}
+              value={value?.repEmail ?? ''}
+              onChange={(event) => onChange({ ...withDefaults(value), repEmail: event.target.value })}
+            />
+          </div>
+          <div>
+            <label htmlFor="council-postal" className="text-sm font-medium text-slate-700">
+              Postal address for representations
+            </label>
+            <textarea
+              id="council-postal"
+              className={`${UI.input} mt-1 w-full min-h-[80px]`}
+              value={value?.repPostal ?? ''}
+              onChange={(event) => onChange({ ...withDefaults(value), repPostal: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div>
+              <label htmlFor="council-office" className="text-sm font-medium text-slate-700">
+                Council office address (optional)
+              </label>
+              <input
+                id="council-office"
+                className={`${UI.input} mt-1 w-full`}
+                value={value?.officeAddress ?? ''}
+                onChange={(event) => onChange({ ...withDefaults(value), officeAddress: event.target.value })}
+              />
+            </div>
+            <div>
+              <label htmlFor="council-website" className="text-sm font-medium text-slate-700">
+                Council website (optional)
+              </label>
+              <input
+                id="council-website"
+                className={`${UI.input} mt-1 w-full`}
+                value={value?.website ?? ''}
+                onChange={(event) => onChange({ ...withDefaults(value), website: event.target.value })}
+              />
+            </div>
+          </div>
         </div>
-        <div>
-          <label htmlFor="council-postal" className="text-sm font-medium text-slate-700">
-            Postal address for representations
-          </label>
-          <textarea
-            id="council-postal"
-            className={`${UI.input} mt-1 w-full min-h-[80px]`}
-            value={value?.repPostal ?? ''}
-            onChange={(event) => onChange({ ...withDefaults(value), repPostal: event.target.value })}
-          />
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/features/template/components/InfoTooltip.tsx
+++ b/src/features/template/components/InfoTooltip.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+type InfoTooltipProps = {
+  content: React.ReactNode;
+  label?: string;
+  id?: string;
+};
+
+export default function InfoTooltip({ content, label = 'More information', id }: InfoTooltipProps) {
+  const [open, setOpen] = React.useState(false);
+  const tooltipId = id ?? React.useId();
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent | PointerEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+      if (panelRef.current?.contains(target)) return;
+      if (buttonRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+      document.removeEventListener('mousedown', handlePointerDown);
+    };
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    panelRef.current?.focus();
+  }, [open]);
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        ref={buttonRef}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-[11px] font-semibold text-slate-600 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={tooltipId}
+        onClick={() => setOpen((prev) => !prev)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+      >
+        <span aria-hidden>i</span>
+        <span className="sr-only">{label}</span>
+      </button>
+      {open && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          ref={panelRef}
+          tabIndex={-1}
+          className="absolute z-30 mt-2 w-64 rounded-xl border border-slate-200 bg-white p-3 text-left text-xs text-slate-700 shadow-lg"
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/template/noticeRenderer.ts
+++ b/src/features/template/noticeRenderer.ts
@@ -25,6 +25,14 @@ const dayLabels: Record<typeof dayOrder[number], string> = {
   sun: 'Sun',
 };
 
+const missingToken = (field: string): string => `[[missing: ${field}]]`;
+
+const ensureValue = (value: string | null | undefined, field: string): string => {
+  const trimmed = value?.trim();
+  if (trimmed) return trimmed;
+  return missingToken(field);
+};
+
 export const hasEnabledHours = (activities: Activities | undefined | null): boolean => {
   if (!activities) return false;
   return Object.values(activities).some((week) => {
@@ -33,7 +41,7 @@ export const hasEnabledHours = (activities: Activities | undefined | null): bool
   });
 };
 
-const formatTimeRange = (start: string, end: string): string => `${start}–${end}`;
+const formatTimeRange = (start: string, end: string): string => `${start}–${end === '00:00' ? '00:00' : end}`;
 
 const renderActivityRow = (label: string, hours?: Activities[keyof Activities]): string => {
   if (!hours) return '';
@@ -47,36 +55,33 @@ const renderActivityRow = (label: string, hours?: Activities[keyof Activities]):
   return `${label} | ${cells.join(' | ')}`;
 };
 
-const ensureSentence = (value: string): string => {
+const ensureSentence = (value: string, field: string): string => {
   const trimmed = value.trim();
-  if (!trimmed) return '';
+  if (!trimmed) return missingToken(field);
   if (/[.!?]$/.test(trimmed)) return trimmed;
   return `${trimmed}.`;
 };
 
+const addressOrMissing = (address: AddressValue | null | undefined, field: string): string => {
+  if (!address) return missingToken(field);
+  const line1 = address.line1?.trim();
+  const town = address.town?.trim();
+  const postcode = address.postcode?.trim();
+  if (!line1 || !town || !postcode) return missingToken(field);
+  return [line1, address.line2?.trim(), town, postcode].filter(Boolean).join(', ');
+};
+
 export const renderActivitiesTable = (activities?: Activities): string => {
-  if (!activities) {
-    return 'No licensable activities selected.';
+  if (!activities || !hasEnabledHours(activities)) {
+    return missingToken('activities');
   }
   const header = ['Activity', ...dayOrder.map((day) => dayLabels[day])];
-  const rows = [header.join(' | ')];
-  rows.push(header.map(() => '---').join(' | '));
+  const rows = [header.join(' | '), header.map(() => '---').join(' | ')];
   (Object.keys(activityLabels) as ActivityKey[]).forEach((key) => {
     const row = renderActivityRow(activityLabels[key], activities[key]);
     if (row) rows.push(row);
   });
-  if (rows.length === 2) {
-    rows.push('No licensable activities are selected.');
-  }
   return rows.join('\n');
-};
-
-const oneLineAddress = (address?: AddressValue | null): string => {
-  if (!address) return '';
-  return [address.line1, address.line2, address.town, address.postcode]
-    .map((part) => (part || '').trim())
-    .filter(Boolean)
-    .join(', ');
 };
 
 const formatDeadline = (iso: string): string => {
@@ -87,31 +92,38 @@ const formatDeadline = (iso: string): string => {
 };
 
 const fallbackPremisesName = (notice: TemplateNotice): string => {
-  const { premisesName, tradingName } = notice;
-  if (premisesName && premisesName.trim()) return premisesName.trim();
-  if (tradingName && tradingName.trim()) return tradingName.trim();
-  const address = oneLineAddress(notice.premisesAddress);
-  return address || 'the premises';
+  const primary = notice.premisesName?.trim();
+  if (primary) return primary;
+  const trading = notice.tradingName?.trim();
+  if (trading) return trading;
+  const address = addressOrMissing(notice.premisesAddress, 'premisesAddress');
+  if (address.startsWith('[[missing')) return missingToken('premisesName');
+  return address;
 };
 
 const renderStandardFooter = (notice: TemplateNotice): string[] => {
   const council = notice.council;
   const lines: string[] = [];
-  const repEmail = council?.repEmail ?? notice.representationChannel?.email ?? '';
-  const repPostal = council?.repPostal ?? notice.representationChannel?.postal ?? '';
-  const deadline = formatDeadline(notice.representationDeadline);
-  const councilName = council?.name ?? '';
+  const repEmail = ensureValue(council?.repEmail, 'councilRepEmail');
+  const repPostal = ensureValue(council?.repPostal, 'councilRepPostal');
+  const deadline = ensureValue(formatDeadline(notice.representationDeadline), 'representationDeadline');
 
   lines.push(
-    `Any person wishing to make representations concerning this application shall give notice in writing to ${repPostal || 'the licensing authority'} or by email to ${repEmail || 'the licensing authority'} no later than ${deadline || 'the stated deadline'}.`
+    `Any person wishing to make representations concerning this application shall give notice in writing to ${repPostal} or by email to ${repEmail} no later than ${deadline}.`
   );
 
-  if (council?.officeAddress || council?.website) {
-    const office = council.officeAddress || 'the council offices';
-    const website = council.website || 'the council website';
-    lines.push(`A record of the application may be inspected at ${office} during normal office hours or via ${website}.`);
-  } else if (councilName) {
-    lines.push(`A record of the application may be inspected at the offices of ${councilName} during normal office hours.`);
+  const office = council?.officeAddress?.trim();
+  const website = council?.website?.trim();
+  const councilName = council?.name?.trim();
+
+  if (office || website) {
+    lines.push(
+      `A record of the application may be inspected at ${ensureValue(office, 'councilOfficeAddress')} during normal office hours or via ${ensureValue(website, 'councilWebsite')}.`
+    );
+  } else {
+    lines.push(
+      `A record of the application may be inspected at ${ensureValue(councilName, 'councilName')} during normal office hours.`
+    );
   }
 
   lines.push(
@@ -122,10 +134,10 @@ const renderStandardFooter = (notice: TemplateNotice): string[] => {
 };
 
 export const buildNoticeText = (notice: TemplateNotice): string => {
-  const councilName = notice.council?.name || 'the licensing authority';
-  const applicantName = notice.applicantName || 'the applicant';
+  const applicantName = ensureValue(notice.applicantLegalName, 'applicantLegalName');
+  const councilName = ensureValue(notice.council?.name, 'councilName');
   const premises = fallbackPremisesName(notice);
-  const premisesAddress = oneLineAddress(notice.premisesAddress);
+  const premisesAddress = addressOrMissing(notice.premisesAddress, 'premisesAddress');
   const activitiesTable = renderActivitiesTable(notice.activities);
   const footer = renderStandardFooter(notice);
 
@@ -134,10 +146,10 @@ export const buildNoticeText = (notice: TemplateNotice): string => {
       'LICENSING ACT 2003',
       `NOTICE IS HEREBY GIVEN that ${applicantName} has applied to ${councilName} to vary the premises licence in respect of ${premises}, ${premisesAddress}.`,
       '',
-      `The proposed variation is as follows: ${ensureSentence(notice.variationDescription || '')}`,
+      `The proposed variation is as follows: ${ensureSentence(notice.variationDescription || '', 'variationDescription')}`,
     ];
 
-    if (hasEnabledHours(notice.activities)) {
+    if (!activitiesTable.startsWith('[[missing')) {
       paragraphs.push('', 'The application also seeks to permit the following licensable activities and hours:', activitiesTable);
     }
 
@@ -146,11 +158,11 @@ export const buildNoticeText = (notice: TemplateNotice): string => {
   }
 
   if (notice.noticeType === 'review') {
-    const reviewApplicant = (notice.reviewApplicant || notice.applicantName || '').trim();
-    const reviewGrounds = ensureSentence(notice.reviewGrounds || '');
+    const reviewApplicant = ensureValue(notice.reviewApplicant || notice.applicantLegalName, 'reviewApplicant');
+    const reviewGrounds = ensureSentence(notice.reviewGrounds || '', 'reviewGrounds');
     const paragraphs = [
       'LICENSING ACT 2003',
-      `NOTICE IS HEREBY GIVEN that an application has been made by ${reviewApplicant || applicantName} to ${councilName} for a review of the premises licence in respect of ${premises}, ${premisesAddress}.`,
+      `NOTICE IS HEREBY GIVEN that an application has been made by ${reviewApplicant} to ${councilName} for a review of the premises licence in respect of ${premises}, ${premisesAddress}.`,
       '',
       `The grounds for the review are as follows: ${reviewGrounds}`,
       '',
@@ -166,8 +178,8 @@ export const buildNoticeText = (notice: TemplateNotice): string => {
     'The application is to permit the following licensable activities and hours:',
     activitiesTable,
   ];
-  const conditionsSentence = ensureSentence(notice.conditionsSummary || '');
-  if (conditionsSentence) {
+  const conditionsSentence = ensureSentence(notice.conditionsSummary || '', 'conditionsSummary');
+  if (!conditionsSentence.startsWith('[[missing')) {
     paragraphs.push('', `Summary of proposed conditions: ${conditionsSentence}`);
   }
   paragraphs.push('', ...footer);

--- a/src/features/template/schema.ts
+++ b/src/features/template/schema.ts
@@ -6,6 +6,17 @@ export const ukPostcode = /^(GIR 0AA|(?:(?:[A-Z]{1,2}\d{1,2}|[A-Z]{1,2}\d[A-Z]|[
 
 const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
 
+const timeToMinutes = (value: string): number => {
+  const [hours, minutes] = value.split(':').map(Number);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return 0;
+  return hours * 60 + minutes;
+};
+
+const endTimeToMinutes = (value: string): number => {
+  if (value === '00:00') return 24 * 60;
+  return timeToMinutes(value);
+};
+
 export const HoursRangeSchema = z
   .object({
     enabled: z.boolean(),
@@ -14,7 +25,9 @@ export const HoursRangeSchema = z
   })
   .superRefine((value, ctx) => {
     if (!value.enabled) return;
-    if (value.start >= value.end) {
+    const startMinutes = timeToMinutes(value.start);
+    const endMinutes = endTimeToMinutes(value.end);
+    if (startMinutes >= endMinutes) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'End must be after start',
@@ -46,11 +59,58 @@ const ActivitiesShape: Record<ActivityKey, z.ZodOptional<z.ZodType<WeekHours>>> 
 export const ActivitiesSchema: z.ZodType<Activities> = z.object(ActivitiesShape).partial();
 
 const AddressSchema = z.object({
-  line1: z.string().min(2, 'Address line required'),
+  line1: z.string().min(2, 'Address line 1 is required'),
   line2: z.string().optional(),
-  town: z.string().optional(),
+  town: z.string().min(2, 'Town or city is required'),
   postcode: z.string().regex(ukPostcode, 'Postcode must be UK format'),
 });
+
+const DeclEditMetaSchema = z
+  .object({
+    deadlineEdited: z.boolean(),
+    deadlineEditReason: z.string().trim().min(3, 'Provide a reason for the edit').max(160).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.deadlineEdited && !value.deadlineEditReason) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide a reason for overriding the calculated deadline.',
+        path: ['deadlineEditReason'],
+      });
+    }
+  });
+
+const contactPhoneSchema = z
+  .string({ required_error: 'Phone number is required' })
+  .trim()
+  .min(7, 'Phone must be 7–20 characters')
+  .max(20, 'Phone must be 7–20 characters')
+  .superRefine((value, ctx) => {
+    const compact = value.replace(/[\s()\-]/g, '');
+    if (!compact) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Phone number is required',
+      });
+      return;
+    }
+    if (!/^\+?\d{7,20}$/.test(compact)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Enter a UK or international number',
+      });
+      return;
+    }
+    if (compact.startsWith('+') || compact.startsWith('00')) {
+      return;
+    }
+    if (!compact.startsWith('0')) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Use a UK (0...) or + international number',
+      });
+    }
+  });
 
 const CouncilSchema = z.object({
   name: z.string().min(2, 'Council required'),
@@ -66,24 +126,20 @@ const CouncilSchema = z.object({
     .optional(),
 });
 
-const SharedSchema = z.object({
+const SharedBase = z.object({
   noticeType: z.enum(['new', 'variation', 'review']).nullable(),
-  applicantName: z.string().min(2).max(100),
-  applicantAddress: z.string().min(5).max(400),
-  contactEmail: z.string().email(),
-  contactPhone: z
-    .string()
-    .trim()
-    .refine((value) => value.length === 0 || (value.length >= 7 && value.length <= 20), {
-      message: 'Phone must be 7–20 characters',
-    })
-    .optional(),
+  applicantLegalName: z.string().min(2, 'Applicant legal name is required').max(100),
+  applicantAddressType: z.enum(['registeredOffice', 'homeAddress']),
+  applicantAddress: AddressSchema,
+  contactEmail: z.string().email('Use a valid email address'),
+  contactPhone: contactPhoneSchema,
   premisesName: z.string().max(100).optional(),
   tradingName: z.string().max(100).optional(),
   premisesAddress: AddressSchema.nullable(),
   council: CouncilSchema.nullable(),
   intendedPublicationDate: z.string(),
   representationDeadline: z.string(),
+  declarationAccepted: z.boolean(),
   representationChannel: z
     .object({
       email: z.string().email().optional(),
@@ -96,54 +152,89 @@ const SharedSchema = z.object({
   variationDescription: z.string().max(500).optional(),
   reviewApplicant: z.string().max(100).optional(),
   reviewGrounds: z.string().max(500).optional(),
+  declEditMeta: DeclEditMetaSchema.optional(),
   autosaveVersion: z.number().optional(),
 });
 
-const NewNoticeSchema = SharedSchema.extend({
-  noticeType: z.literal('new'),
-  activities: ActivitiesSchema.superRefine((value, ctx) => {
-    const hasEnabled = Object.values(value || {}).some((week) =>
-      week ? Object.values(week).some((day) => day?.enabled) : false
-    );
-    if (!hasEnabled) {
+type SharedRefinementFields = {
+  premisesName?: string | null;
+  tradingName?: string | null;
+  premisesAddress?: unknown | null;
+};
+
+const withSharedRefinements = <T extends z.ZodTypeAny>(schema: T) =>
+  schema.superRefine((value: SharedRefinementFields, ctx) => {
+    const hasPremisesName = typeof value.premisesName === 'string' ? value.premisesName.trim() : '';
+    const hasTradingName = typeof value.tradingName === 'string' ? value.tradingName.trim() : '';
+    if (!hasPremisesName && !hasTradingName) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [],
-        message: 'Select at least one licensable activity and provide hours',
+        message: 'Provide either a premises name or a trading name.',
+        path: ['tradingName'],
       });
     }
-  }),
-  conditionsSummary: z.string().max(400).optional(),
-});
-
-const VariationNoticeSchema = SharedSchema.extend({
-  noticeType: z.literal('variation'),
-  variationDescription: z.string().min(20).max(500),
-  activities: ActivitiesSchema.optional(),
-}).superRefine((value, ctx) => {
-  if (value.activities) {
-    const hasEnabled = Object.values(value.activities).some((week) =>
-      week ? Object.values(week).some((day) => day?.enabled) : false
-    );
-    if (!hasEnabled) {
+    if (value.premisesAddress == null) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['activities'],
-        message: 'Any listed activity must include enabled hours',
+        message: 'Premises address is required',
+        path: ['premisesAddress'],
       });
     }
-  }
-});
+  });
 
-const ReviewNoticeSchema = SharedSchema.extend({
-  noticeType: z.literal('review'),
-  reviewApplicant: z.string().max(100).optional(),
-  reviewGrounds: z.string().min(20).max(500),
-});
+const NewNoticeSchema = withSharedRefinements(
+  SharedBase.extend({
+    noticeType: z.literal('new'),
+    activities: ActivitiesSchema.superRefine((value, ctx) => {
+      const hasEnabled = Object.values(value || {}).some((week) =>
+        week ? Object.values(week).some((day) => day?.enabled) : false
+      );
+      if (!hasEnabled) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [],
+          message: 'Select at least one licensable activity and provide hours',
+        });
+      }
+    }),
+    conditionsSummary: z.string().max(400).optional(),
+  })
+);
 
-const NullNoticeSchema = SharedSchema.extend({
-  noticeType: z.null(),
-});
+const VariationNoticeSchema = withSharedRefinements(
+  SharedBase.extend({
+    noticeType: z.literal('variation'),
+    variationDescription: z.string().min(20).max(500),
+    activities: ActivitiesSchema.optional(),
+  }).superRefine((value, ctx) => {
+    if (value.activities) {
+      const hasEnabled = Object.values(value.activities).some((week) =>
+        week ? Object.values(week).some((day) => day?.enabled) : false
+      );
+      if (!hasEnabled) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['activities'],
+          message: 'Any listed activity must include enabled hours',
+        });
+      }
+    }
+  })
+);
+
+const ReviewNoticeSchema = withSharedRefinements(
+  SharedBase.extend({
+    noticeType: z.literal('review'),
+    reviewApplicant: z.string().max(100).optional(),
+    reviewGrounds: z.string().min(20).max(500),
+  })
+);
+
+const NullNoticeSchema = withSharedRefinements(
+  SharedBase.extend({
+    noticeType: z.null(),
+  })
+);
 
 export const TemplateNoticeSchema: z.ZodType<TemplateNotice> = z.union([
   NewNoticeSchema,
@@ -181,26 +272,34 @@ export const DefaultActivities = (): Activities => ({
   similar: DefaultWeekHours(),
 });
 
-export const createEmptyNotice = (): TemplateNotice => ({
-  noticeType: null,
-  applicantName: '',
-  applicantAddress: '',
-  contactEmail: '',
-  contactPhone: '',
-  premisesName: '',
-  tradingName: '',
-  premisesAddress: null,
-  council: null,
-  intendedPublicationDate: dayjs().format('YYYY-MM-DD'),
-  representationDeadline: '',
-  representationChannel: undefined,
-  activities: DefaultActivities(),
-  conditionsSummary: '',
-  variationDescription: '',
-  reviewApplicant: '',
-  reviewGrounds: '',
-  autosaveVersion: 1,
-});
+const emptyAddress = () => ({ line1: '', line2: '', town: '', postcode: '' });
+
+export const createEmptyNotice = (): TemplateNotice => {
+  const publicationDate = dayjs().format('YYYY-MM-DD');
+  return {
+    noticeType: null,
+    applicantLegalName: '',
+    applicantAddressType: 'registeredOffice',
+    applicantAddress: emptyAddress(),
+    contactEmail: '',
+    contactPhone: '',
+    premisesName: '',
+    tradingName: '',
+    premisesAddress: emptyAddress(),
+    council: null,
+    intendedPublicationDate: publicationDate,
+    representationDeadline: calculateRepresentationDeadline(publicationDate),
+    declarationAccepted: false,
+    representationChannel: undefined,
+    activities: DefaultActivities(),
+    conditionsSummary: '',
+    variationDescription: '',
+    reviewApplicant: '',
+    reviewGrounds: '',
+    declEditMeta: undefined,
+    autosaveVersion: 1,
+  };
+};
 
 export const calculateRepresentationDeadline = (
   publicationDateIso: string,

--- a/src/features/template/steps/StepBuild.tsx
+++ b/src/features/template/steps/StepBuild.tsx
@@ -1,33 +1,85 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useForm, type Resolver } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import dayjs from 'dayjs';
 import * as UI from '@/styles/ui';
 import ErrorSummary, { type ErrorItem } from '@/components/publish/ErrorSummary';
 import ActivityHoursMatrix from '../components/ActivityHoursMatrix';
 import AddressPicker from '../components/AddressPicker';
 import CouncilContactAuto from '../components/CouncilContactAuto';
 import InlineHelp from '../components/InlineHelp';
-import { TemplateNoticeSchema, createEmptyNotice } from '../schema';
-import { useTemplateBuilder, useTemplateNotice, useTemplateStep } from '../TemplateBuilderProvider';
-import type { TemplateNotice } from '../types';
+import InfoTooltip from '../components/InfoTooltip';
+import {
+  TemplateNoticeSchema,
+  createEmptyNotice,
+  calculateRepresentationDeadline,
+} from '../schema';
+import {
+  useTemplateBuilder,
+  useTemplateNotice,
+  useTemplateStep,
+} from '../TemplateBuilderProvider';
+import type { AddressValue, DeclEditMeta, TemplateNotice } from '../types';
+import { readProfilePrefill, trackTemplateEvent } from '../telemetry';
+
+const CONDITION_SNIPPETS = [
+  'Doors and windows closed after 23:00 except for access/egress.',
+  'CCTV covering entry/exit retained for 31 days.',
+  'Challenge 25 policy in operation.',
+];
+
+const ADDRESS_HINT: Record<TemplateNotice['applicantAddressType'], string> = {
+  registeredOffice: 'We will show the registered office exactly as entered above on the notice.',
+  homeAddress: 'We will show the applicant\'s home address on the notice.',
+};
 
 function flattenErrors(errors: any, path: string[] = []): ErrorItem[] {
   if (!errors) return [];
   if (errors.message) {
-    return [{ field: (path.join('-') || 'field'), message: errors.message }];
+    return [{ field: path.join('-') || 'field', message: errors.message }];
   }
   if (typeof errors !== 'object') return [];
   return Object.entries(errors).flatMap(([key, value]) => flattenErrors(value, [...path, key]));
 }
 
+function mapAddressErrors(error: unknown): Partial<Record<keyof AddressValue, string>> {
+  if (!error || typeof error !== 'object') return {};
+  const output: Partial<Record<keyof AddressValue, string>> = {};
+  for (const key of ['line1', 'line2', 'town', 'postcode'] as const) {
+    const field = (error as Record<string, any>)[key];
+    if (field?.message) {
+      output[key] = field.message as string;
+    }
+  }
+  return output;
+}
+
+function normaliseProfileAddress(address: any): AddressValue | null {
+  if (!address || typeof address !== 'object') return null;
+  const line1 = typeof address.line1 === 'string' ? address.line1 : '';
+  const town = typeof address.town === 'string' ? address.town : '';
+  const postcode = typeof address.postcode === 'string' ? address.postcode : '';
+  const line2 = typeof address.line2 === 'string' ? address.line2 : '';
+  if (!line1 && !town && !postcode) return null;
+  return { line1, town, postcode, line2 };
+}
+
+function formatDeadlineDisplay(iso: string): string {
+  if (!iso) return '';
+  const parsed = dayjs(iso);
+  if (!parsed.isValid()) return '';
+  return parsed.format('D MMMM YYYY');
+}
+
 export default function StepBuild() {
   const notice = useTemplateNotice();
-  const { patchNotice } = useTemplateBuilder();
+  const { state, patchNotice } = useTemplateBuilder();
   const [, setStep] = useTemplateStep();
-
   const resolver = React.useMemo(
     () =>
-      zodResolver<TemplateNotice, TemplateNotice, TemplateNotice>(TemplateNoticeSchema as any) as Resolver<TemplateNotice>,
+      zodResolver<TemplateNotice, TemplateNotice, TemplateNotice>(
+        TemplateNoticeSchema as any
+      ) as Resolver<TemplateNotice>,
     []
   );
 
@@ -37,7 +89,7 @@ export default function StepBuild() {
     mode: 'onChange',
   });
 
-  const errors = useMemo(() => flattenErrors(form.formState.errors), [form.formState.errors]);
+  const errors = React.useMemo(() => flattenErrors(form.formState.errors), [form.formState.errors]);
 
   React.useEffect(() => {
     form.reset(notice);
@@ -45,11 +97,135 @@ export default function StepBuild() {
   }, [notice.noticeType]);
 
   React.useEffect(() => {
+    if (!state.restoredFromDraft) return;
+    form.reset(state.notice);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.restoredFromDraft]);
+
+  React.useEffect(() => {
     const subscription = form.watch((value) => {
       patchNotice(value as Partial<TemplateNotice>, true);
     });
     return () => subscription.unsubscribe();
   }, [form, patchNotice]);
+
+  const appliedPrefillRef = React.useRef(false);
+  React.useEffect(() => {
+    if (appliedPrefillRef.current) return;
+    if (state.restoredFromDraft) return;
+    const profile = readProfilePrefill<Record<string, any>>();
+    if (!profile) return;
+    const updates: Partial<TemplateNotice> = {};
+    const current = form.getValues();
+    if (!current.applicantLegalName && typeof profile.applicantLegalName === 'string') {
+      updates.applicantLegalName = profile.applicantLegalName;
+    }
+    if (typeof profile.applicantAddressType === 'string') {
+      if (profile.applicantAddressType === 'homeAddress' || profile.applicantAddressType === 'registeredOffice') {
+        updates.applicantAddressType = profile.applicantAddressType;
+      }
+    }
+    const address = normaliseProfileAddress(profile.applicantAddress);
+    if (address) {
+      updates.applicantAddress = {
+        line1: address.line1 || current.applicantAddress.line1,
+        line2: address.line2 || current.applicantAddress.line2,
+        town: address.town || current.applicantAddress.town,
+        postcode: address.postcode || current.applicantAddress.postcode,
+      };
+    }
+    if (!current.contactEmail && typeof profile.contactEmail === 'string') {
+      updates.contactEmail = profile.contactEmail;
+    }
+    if (!current.contactPhone && typeof profile.contactPhone === 'string') {
+      updates.contactPhone = profile.contactPhone;
+    }
+    if (Object.keys(updates).length > 0) {
+      Object.entries(updates).forEach(([key, value]) => {
+        form.setValue(key as keyof TemplateNotice, value as any, {
+          shouldDirty: true,
+          shouldValidate: true,
+        });
+      });
+      patchNotice(updates, true);
+    }
+    appliedPrefillRef.current = true;
+  }, [form, patchNotice, state.restoredFromDraft]);
+
+  const activities = form.watch('activities') ?? {};
+  const publicationDate = form.watch('intendedPublicationDate');
+  const council = form.watch('council');
+  const currentDeadline = form.watch('representationDeadline');
+  const deadlineMeta = form.watch('declEditMeta') as DeclEditMeta | undefined;
+  const applicantAddressType = form.watch('applicantAddressType');
+
+  const autoDeadline = React.useMemo(
+    () =>
+      calculateRepresentationDeadline(publicationDate, {
+        shiftWeekend: council?.policy?.shiftWeekendDeadline === true,
+      }),
+    [publicationDate, council?.policy?.shiftWeekendDeadline]
+  );
+
+  const [deadlineDialogOpen, setDeadlineDialogOpen] = React.useState(false);
+  const [deadlineDraft, setDeadlineDraft] = React.useState<{ date: string; reason: string }>({
+    date: currentDeadline || autoDeadline || '',
+    reason: deadlineMeta?.deadlineEditReason ?? '',
+  });
+  const [deadlineError, setDeadlineError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!deadlineDialogOpen) return;
+    setDeadlineDraft({
+      date: currentDeadline || autoDeadline || '',
+      reason: deadlineMeta?.deadlineEditReason ?? '',
+    });
+    setDeadlineError(null);
+  }, [deadlineDialogOpen, currentDeadline, autoDeadline, deadlineMeta?.deadlineEditReason]);
+
+  const handleDeadlineConfirm = () => {
+    const trimmedReason = deadlineDraft.reason.trim();
+    if (!deadlineDraft.date) {
+      setDeadlineError('Select a representation deadline.');
+      return;
+    }
+    if (deadlineDraft.date === autoDeadline) {
+      form.setValue('representationDeadline', deadlineDraft.date, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      form.setValue('declEditMeta', undefined, { shouldDirty: true, shouldValidate: true });
+      setDeadlineDialogOpen(false);
+      return;
+    }
+    if (trimmedReason.length < 3) {
+      setDeadlineError('Provide a short reason for overriding the deadline.');
+      return;
+    }
+    form.setValue('representationDeadline', deadlineDraft.date, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    form.setValue(
+      'declEditMeta',
+      { deadlineEdited: true, deadlineEditReason: trimmedReason },
+      { shouldDirty: true, shouldValidate: true }
+    );
+    trackTemplateEvent('deadline_edited', {
+      autoDeadline,
+      newDeadline: deadlineDraft.date,
+    });
+    setDeadlineDialogOpen(false);
+  };
+
+  const handleDeadlineReset = () => {
+    if (!autoDeadline) return;
+    form.setValue('representationDeadline', autoDeadline, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    form.setValue('declEditMeta', undefined, { shouldDirty: true, shouldValidate: true });
+  };
 
   const handleSubmit = form.handleSubmit(
     (data) => {
@@ -61,8 +237,35 @@ export default function StepBuild() {
     }
   );
 
+  const applicantAddressErrors = mapAddressErrors(form.formState.errors.applicantAddress);
+  const premisesAddressErrors = mapAddressErrors(form.formState.errors.premisesAddress);
+
   const selectedType = notice.noticeType;
-  const activities = form.watch('activities') ?? {};
+
+  const addConditionSnippet = (snippet: string) => {
+    const existing = form.getValues('conditionsSummary') || '';
+    if (existing.includes(snippet)) return;
+    const next = existing ? `${existing.trim()}\n${snippet}` : snippet;
+    form.setValue('conditionsSummary', next, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    trackTemplateEvent('conditions_snippet_added', { snippet });
+  };
+
+  const representationHelp = (
+    <div className="space-y-2">
+      <p>
+        Calculated as intended publication date + 28 days (Licensing Act 2003). Bank holidays or working-day
+        policies may apply.
+      </p>
+      {autoDeadline && (
+        <p className="font-medium text-slate-800">Automatic deadline: {formatDeadlineDisplay(autoDeadline)}</p>
+      )}
+    </div>
+  );
+
+  const showDeadlineReset = !!deadlineMeta?.deadlineEdited && !!autoDeadline;
 
   return (
     <section className="space-y-4" aria-label="Build notice">
@@ -71,45 +274,79 @@ export default function StepBuild() {
         <section className={`${UI.card} p-5 md:p-6 space-y-4`}>
           <div>
             <h2 className="text-base font-semibold text-blue-900">Applicant details</h2>
-            <InlineHelp id="applicant-help">Enter the legal entity responsible for the notice.</InlineHelp>
+            <InlineHelp id="applicant-help">
+              Full legal entity or individual name, exactly as on the licensing application submitted to the council.
+            </InlineHelp>
           </div>
           <div className="grid grid-cols-1 gap-4">
             <div>
-              <label htmlFor="applicantName" className="text-sm font-medium text-slate-700">
-                Applicant name
+              <label htmlFor="applicantLegalName" className="text-sm font-medium text-slate-700">
+                Applicant legal name
               </label>
               <input
-                id="applicantName"
+                id="applicantLegalName"
                 className={`${UI.input} mt-1 w-full`}
-                {...form.register('applicantName')}
+                {...form.register('applicantLegalName')}
               />
-              {form.formState.errors.applicantName && (
+              {form.formState.errors.applicantLegalName && (
                 <p className="mt-1 text-sm text-amber-700">
-                  {form.formState.errors.applicantName.message as string}
+                  {form.formState.errors.applicantLegalName.message as string}
                 </p>
               )}
             </div>
-            <div>
-              <label htmlFor="applicantAddress" className="text-sm font-medium text-slate-700">
-                Applicant address
-              </label>
-              <textarea
-                id="applicantAddress"
-                className={`${UI.input} mt-1 w-full min-h-[120px]`}
-                {...form.register('applicantAddress')}
-              />
-              {form.formState.errors.applicantAddress && (
-                <p className="mt-1 text-sm text-amber-700">
-                  {form.formState.errors.applicantAddress.message as string}
-                </p>
-              )}
-            </div>
+            <fieldset className="space-y-3" aria-labelledby="address-type-legend">
+              <legend id="address-type-legend" className="text-sm font-semibold text-blue-900">
+                Address type
+              </legend>
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="flex items-start gap-2 rounded-xl border border-slate-200 p-3">
+                  <input
+                    type="radio"
+                    className="mt-1 h-4 w-4 text-blue-600 focus:ring-blue-500"
+                    value="registeredOffice"
+                    {...form.register('applicantAddressType')}
+                    checked={applicantAddressType === 'registeredOffice'}
+                  />
+                  <span className="text-sm text-slate-700">
+                    <span className="font-medium text-slate-900">Registered office (company)</span>
+                    <br />Use the address registered with Companies House.
+                  </span>
+                </label>
+                <label className="flex items-start gap-2 rounded-xl border border-slate-200 p-3">
+                  <input
+                    type="radio"
+                    className="mt-1 h-4 w-4 text-blue-600 focus:ring-blue-500"
+                    value="homeAddress"
+                    {...form.register('applicantAddressType')}
+                    checked={applicantAddressType === 'homeAddress'}
+                  />
+                  <span className="text-sm text-slate-700">
+                    <span className="font-medium text-slate-900">Home address (individual)</span>
+                    <br />Use the applicant’s residential address.
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+            <AddressPicker
+              id="applicantAddress"
+              label="Applicant address"
+              value={form.watch('applicantAddress')}
+              onChange={(next) =>
+                form.setValue('applicantAddress', next, { shouldDirty: true, shouldValidate: true })
+              }
+              errors={applicantAddressErrors}
+              footnote={ADDRESS_HINT[applicantAddressType]}
+            />
             <div className="grid gap-4 md:grid-cols-2">
               <div>
                 <label htmlFor="contactEmail" className="text-sm font-medium text-slate-700">
                   Contact email
                 </label>
-                <input id="contactEmail" className={`${UI.input} mt-1 w-full`} {...form.register('contactEmail')} />
+                <input
+                  id="contactEmail"
+                  className={`${UI.input} mt-1 w-full`}
+                  {...form.register('contactEmail')}
+                />
                 {form.formState.errors.contactEmail && (
                   <p className="mt-1 text-sm text-amber-700">
                     {form.formState.errors.contactEmail.message as string}
@@ -118,7 +355,7 @@ export default function StepBuild() {
               </div>
               <div>
                 <label htmlFor="contactPhone" className="text-sm font-medium text-slate-700">
-                  Contact phone (optional)
+                  Phone
                 </label>
                 <input id="contactPhone" className={`${UI.input} mt-1 w-full`} {...form.register('contactPhone')} />
                 {form.formState.errors.contactPhone && (
@@ -126,6 +363,9 @@ export default function StepBuild() {
                     {form.formState.errors.contactPhone.message as string}
                   </p>
                 )}
+                <p className="mt-1 text-xs text-slate-500">
+                  Required for urgent licensing queries — UK or international format.
+                </p>
               </div>
             </div>
           </div>
@@ -134,40 +374,43 @@ export default function StepBuild() {
         <section className={`${UI.card} p-5 md:p-6 space-y-4`}>
           <div>
             <h2 className="text-base font-semibold text-blue-900">Premises details</h2>
-            <InlineHelp id="premises-help">This appears in the notice and letter to the council.</InlineHelp>
+            <InlineHelp id="premises-help">
+              These details appear in the public notice and correspondence to the council.
+            </InlineHelp>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div>
               <label htmlFor="premisesName" className="text-sm font-medium text-slate-700">
-                Premises name (optional)
+                Premises name
               </label>
               <input id="premisesName" className={`${UI.input} mt-1 w-full`} {...form.register('premisesName')} />
             </div>
             <div>
               <label htmlFor="tradingName" className="text-sm font-medium text-slate-700">
-                Trading name (optional)
+                Trading name
               </label>
               <input id="tradingName" className={`${UI.input} mt-1 w-full`} {...form.register('tradingName')} />
+              {form.formState.errors.tradingName && (
+                <p className="mt-1 text-sm text-amber-700">
+                  {form.formState.errors.tradingName.message as string}
+                </p>
+              )}
             </div>
           </div>
           <AddressPicker
-            id="premises-address-picker"
+            id="premisesAddress"
             label="Premises address"
             value={form.watch('premisesAddress')}
-            onChange={(next) => form.setValue('premisesAddress', next, { shouldValidate: true, shouldDirty: true })}
+            onChange={(next) => form.setValue('premisesAddress', next, { shouldDirty: true, shouldValidate: true })}
+            errors={premisesAddressErrors}
           />
-          {form.formState.errors.premisesAddress && (
-            <p className="mt-1 text-sm text-amber-700">
-              {form.formState.errors.premisesAddress?.message as string}
-            </p>
-          )}
         </section>
 
         <section className={`${UI.card} p-5 md:p-6 space-y-4`}>
           <div>
-            <h2 className="text-base font-semibold text-blue-900">Council & dates</h2>
+            <h2 className="text-base font-semibold text-blue-900">Council &amp; dates</h2>
             <InlineHelp id="council-help">
-              We attempt to auto-fill your licensing authority based on the premises postcode.
+              We auto-fill your licensing authority from the premises postcode. Edit if the lookup is wrong or incomplete.
             </InlineHelp>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
@@ -183,40 +426,83 @@ export default function StepBuild() {
               />
             </div>
             <div>
-              <label htmlFor="representationDeadline" className="text-sm font-medium text-slate-700">
-                Representation deadline
-              </label>
-              <input
-                type="text"
-                id="representationDeadline"
-                className={`${UI.input} mt-1 w-full bg-slate-100 text-slate-600`}
-                value={form.watch('representationDeadline') || ''}
-                readOnly
-              />
+              <div className="flex items-center gap-2">
+                <label htmlFor="representationDeadline" className="text-sm font-medium text-slate-700">
+                  Representation deadline
+                </label>
+                <InfoTooltip content={representationHelp} label="Representation deadline guidance" />
+              </div>
+              <div className="mt-1 flex items-center gap-2">
+                <input
+                  type="date"
+                  id="representationDeadline"
+                  className={`${UI.input} w-full bg-slate-100 text-slate-700`}
+                  value={currentDeadline || ''}
+                  readOnly
+                  aria-readonly="true"
+                />
+                <button
+                  type="button"
+                  className={`${UI.btnSecondary} h-10 px-4 text-xs`}
+                  onClick={() => setDeadlineDialogOpen(true)}
+                >
+                  Edit
+                </button>
+                {showDeadlineReset && (
+                  <button
+                    type="button"
+                    className={`${UI.btnSecondary} h-10 px-4 text-xs`}
+                    onClick={handleDeadlineReset}
+                  >
+                    Reset
+                  </button>
+                )}
+              </div>
+              {deadlineMeta?.deadlineEdited && (
+                <p className="mt-2 text-xs font-medium text-amber-700">
+                  Deadline manually overridden — reason captured for audit.
+                </p>
+              )}
             </div>
           </div>
           <CouncilContactAuto
             postcode={form.watch('premisesAddress')?.postcode ?? ''}
-            value={form.watch('council')}
-            onChange={(next) => form.setValue('council', next, { shouldDirty: true })}
+            value={council}
+            onChange={(next) => form.setValue('council', next, { shouldDirty: true, shouldValidate: true })}
           />
         </section>
 
         <ActivityHoursMatrix
           value={activities}
-          onChange={(next) => form.setValue('activities', next, { shouldDirty: true })}
+          onChange={(next) => form.setValue('activities', next, { shouldDirty: true, shouldValidate: true })}
         />
 
         {selectedType === 'new' && (
           <section className={`${UI.card} p-5 md:p-6 space-y-3`}>
-            <h2 className="text-base font-semibold text-blue-900">Optional conditions summary</h2>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-base font-semibold text-blue-900">Optional conditions</h2>
+              <p className="text-sm text-slate-600">Select snippets or add your own council-friendly wording.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {CONDITION_SNIPPETS.map((snippet) => (
+                <button
+                  type="button"
+                  key={snippet}
+                  className="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  onClick={() => addConditionSnippet(snippet)}
+                >
+                  {snippet}
+                </button>
+              ))}
+            </div>
             <textarea
               id="conditionsSummary"
-              className={`${UI.input} mt-1 w-full min-h-[120px]`}
+              className={`${UI.input} mt-2 w-full min-h-[120px]`}
+              placeholder="Examples: dispersal policy, door supervisors, noise management..."
               {...form.register('conditionsSummary')}
             />
             {form.formState.errors.conditionsSummary && (
-              <p className="mt-1 text-sm text-amber-700">
+              <p className="text-sm text-amber-700">
                 {form.formState.errors.conditionsSummary.message as string}
               </p>
             )}
@@ -276,15 +562,15 @@ export default function StepBuild() {
         )}
 
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
-          <button
-            type="button"
-            className={`${UI.btnSecondary} h-11 px-6 text-sm`}
-            onClick={() => setStep(1)}
-          >
+          <button type="button" className={`${UI.btnSecondary} h-11 px-6 text-sm`} onClick={() => setStep(1)}>
             Back
           </button>
           <div className="flex items-center gap-3">
-            <button type="button" className={`${UI.btnSecondary} h-11 px-6 text-sm`} onClick={() => form.reset(notice)}>
+            <button
+              type="button"
+              className={`${UI.btnSecondary} h-11 px-6 text-sm`}
+              onClick={() => form.reset(notice)}
+            >
               Reset
             </button>
             <button type="submit" className={`${UI.btnPrimary} h-11 px-6 text-sm`}>
@@ -293,6 +579,71 @@ export default function StepBuild() {
           </div>
         </div>
       </form>
+
+      {deadlineDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4">
+          <div className={`${UI.card} w-full max-w-lg space-y-4 p-6`} role="dialog" aria-modal="true">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-lg font-semibold text-blue-900">Override representation deadline</h3>
+                <p className="mt-1 text-sm text-slate-600">
+                  Confirm the new deadline and record why it differs from the automatic calculation.
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close"
+                className={`${UI.btnSecondary} h-9 px-3 text-xs`}
+                onClick={() => setDeadlineDialogOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <label htmlFor="manual-deadline" className="text-sm font-medium text-slate-700">
+                  New representation deadline
+                </label>
+                <input
+                  type="date"
+                  id="manual-deadline"
+                  className={`${UI.input} mt-1 w-full`}
+                  value={deadlineDraft.date}
+                  onChange={(event) => setDeadlineDraft((prev) => ({ ...prev, date: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="deadline-reason" className="text-sm font-medium text-slate-700">
+                  Reason for override
+                </label>
+                <textarea
+                  id="deadline-reason"
+                  className={`${UI.input} mt-1 w-full min-h-[80px]`}
+                  value={deadlineDraft.reason}
+                  onChange={(event) => setDeadlineDraft((prev) => ({ ...prev, reason: event.target.value }))}
+                  placeholder="Example: Council confirmed bank holiday policy shifts deadline to next working day."
+                />
+              </div>
+              <p className="text-xs text-slate-500">
+                Automatic calculation: {autoDeadline ? formatDeadlineDisplay(autoDeadline) : 'Not yet available'}
+              </p>
+              {deadlineError && <p className="text-sm text-amber-700">{deadlineError}</p>}
+            </div>
+            <div className="flex items-center justify-end gap-3 border-t border-slate-200 pt-4">
+              <button
+                type="button"
+                className={`${UI.btnSecondary} h-10 px-4 text-sm`}
+                onClick={() => setDeadlineDialogOpen(false)}
+              >
+                Cancel
+              </button>
+              <button type="button" className={`${UI.btnPrimary} h-10 px-5 text-sm`} onClick={handleDeadlineConfirm}>
+                Save override
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/features/template/steps/StepConfirm.tsx
+++ b/src/features/template/steps/StepConfirm.tsx
@@ -5,19 +5,36 @@ import ComplianceCard from '@/components/publish/RightRail/ComplianceCard';
 import { buildChecklist } from '../checks';
 import { buildNoticeText } from '../noticeRenderer';
 import { useTemplateBuilder, useTemplateNotice, useTemplateStep } from '../TemplateBuilderProvider';
+import { trackTemplateEvent } from '../telemetry';
 
 export default function StepConfirm() {
   const notice = useTemplateNotice();
   const [, setStep] = useTemplateStep();
   const { patchNotice } = useTemplateBuilder();
-  const [confirmed, setConfirmed] = React.useState(false);
   const preview = React.useMemo(() => buildNoticeText(notice), [notice]);
   const checklist = React.useMemo(() => buildChecklist(notice), [notice]);
 
   const handleContinue = () => {
-    if (!confirmed) return;
+    if (!notice.declarationAccepted) return;
     patchNotice({});
     setStep(4);
+  };
+
+  const handleFix = (target?: string) => {
+    trackTemplateEvent('fix_link_clicked', { target });
+    setStep(2);
+    if (!target) return;
+    window.setTimeout(() => {
+      const el = document.getElementById(target);
+      if (!el) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      const focusable = (el.querySelector('input,textarea,select,button,[tabindex]') as HTMLElement | null) || (el as HTMLElement);
+      focusable?.focus?.();
+    }, 120);
+  };
+
+  const toggleDeclaration = (next: boolean) => {
+    patchNotice({ declarationAccepted: next }, true);
   };
 
   return (
@@ -38,17 +55,22 @@ export default function StepConfirm() {
             Edit details
           </button>
         </div>
+        {notice.declEditMeta?.deadlineEdited && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            Deadline edited from auto calculation.
+          </div>
+        )}
         <NoticePreview text={preview} />
         <div className="flex items-start gap-3 border-t border-slate-200 pt-4">
           <input
             id="confirm-notice"
             type="checkbox"
             className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-            checked={confirmed}
-            onChange={(event) => setConfirmed(event.target.checked)}
+            checked={notice.declarationAccepted}
+            onChange={(event) => toggleDeclaration(event.target.checked)}
           />
           <label htmlFor="confirm-notice" className="text-sm text-slate-700">
-            I confirm the notice text is complete and accurate.
+            I confirm the above information is accurate and matches the application submitted to the licensing authority.
           </label>
         </div>
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
@@ -57,15 +79,15 @@ export default function StepConfirm() {
           </button>
           <button
             type="button"
-            className={`${UI.btnPrimary} h-11 px-6 text-sm ${!confirmed ? 'cursor-not-allowed opacity-50' : ''}`}
-            aria-disabled={!confirmed}
+            className={`${UI.btnPrimary} h-11 px-6 text-sm ${!notice.declarationAccepted ? 'cursor-not-allowed opacity-50' : ''}`}
+            aria-disabled={!notice.declarationAccepted}
             onClick={handleContinue}
           >
             Continue to payment
           </button>
         </div>
       </section>
-      <ComplianceCard items={checklist} onFix={() => setStep(2)} />
+      <ComplianceCard items={checklist} onFix={handleFix} />
     </div>
   );
 }

--- a/src/features/template/telemetry.ts
+++ b/src/features/template/telemetry.ts
@@ -1,0 +1,45 @@
+type Payload = Record<string, unknown>;
+
+const GLOBAL_KEYS = ['__NOTICE_PROFILE__', '__PUBLIC_NOTICE_PROFILE__', '__APP_PROFILE__'] as const;
+
+export function readProfilePrefill<T extends Record<string, any> = Payload>(): T | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as Record<string, unknown>;
+  for (const key of GLOBAL_KEYS) {
+    const candidate = w[key];
+    if (candidate && typeof candidate === 'object') {
+      return candidate as T;
+    }
+  }
+  try {
+    const stored = window.localStorage.getItem('notice.profile');
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (parsed && typeof parsed === 'object') {
+        return parsed as T;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export function trackTemplateEvent(event: string, payload: Payload = {}): void {
+  if (typeof window !== 'undefined') {
+    const w = window as any;
+    if (Array.isArray(w.dataLayer)) {
+      w.dataLayer.push({ event, ...payload });
+    } else if (typeof w.track === 'function') {
+      try {
+        w.track(event, payload);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.debug('[template-event]', event, payload);
+  }
+}

--- a/src/features/template/types.ts
+++ b/src/features/template/types.ts
@@ -32,8 +32,13 @@ export type Activities = Partial<Record<ActivityKey, WeekHours>>;
 export interface AddressValue {
   line1: string;
   line2?: string;
-  town?: string;
+  town: string;
   postcode: string;
+}
+
+export interface DeclEditMeta {
+  deadlineEdited: boolean;
+  deadlineEditReason?: string;
 }
 
 export interface CouncilValue {
@@ -50,16 +55,18 @@ export interface CouncilValue {
 
 export interface TemplateNotice {
   noticeType: TemplateNoticeType | null;
-  applicantName: string;
-  applicantAddress: string;
+  applicantLegalName: string;
+  applicantAddressType: 'registeredOffice' | 'homeAddress';
+  applicantAddress: AddressValue;
   contactEmail: string;
-  contactPhone?: string;
+  contactPhone: string;
   premisesName?: string;
   tradingName?: string;
   premisesAddress: AddressValue | null;
   council: CouncilValue | null;
   intendedPublicationDate: string;
   representationDeadline: string;
+  declarationAccepted: boolean;
   representationChannel?: {
     email?: string;
     postal?: string;
@@ -70,6 +77,7 @@ export interface TemplateNotice {
   variationDescription?: string;
   reviewApplicant?: string;
   reviewGrounds?: string;
+  declEditMeta?: DeclEditMeta;
   autosaveVersion?: number;
 }
 


### PR DESCRIPTION
## Summary
- expand the template schema with structured addresses, stricter phone validation, and shared refinements that enforce the premises/trading name requirement
- rebuild the Step 2 builder with address type radios, council deadline override workflow, inline activity hours matrix, and condition snippets while wiring profile prefill and telemetry
- highlight missing variables in the notice preview, gate confirmation behind a declaration checkbox, and add supporting utilities (InfoTooltip, telemetry helpers)

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd499aba0c8330b8e9dfd7dee0e6fd