### PR TITLE
Add @styles alias for Vite and TypeScript

### DIFF
--- a/src/styles/map.css
+++ b/src/styles/map.css
@@ -1,0 +1,4 @@
+#map, .map-container {
+  width: 100%;
+  height: 400px;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@styles/*": ["src/styles/*"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
+      "@styles/*": ["src/styles/*"],
       "lodash.debounce": ["src/shims/lodash.debounce.ts"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,12 @@ export default defineConfig(({ mode }) => {
         globals: { Buffer: true, process: true },
       }),
     ],
-    resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+        '@styles': path.resolve(__dirname, 'src/styles'),
+      },
+    },
     define: {
       'import.meta.env.VITE_NEW_PUBLISH_FLOW': JSON.stringify(newPublishFlow),
       'import.meta.env.NEW_PUBLISH_FLOW': JSON.stringify(newPublishFlow),


### PR DESCRIPTION
## Summary
- add a reusable @styles alias in Vite pointing to src/styles
- mirror the @styles alias in TypeScript configs for editor support
- provide a placeholder src/styles/map.css so imports resolve

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e96f8179b88321a733b32c8f079fa4